### PR TITLE
fixed adding new pipe SizeType in Settings

### DIFF
--- a/src/PrizmMainProject/Forms/Settings/SettingsXtraForm.cs
+++ b/src/PrizmMainProject/Forms/Settings/SettingsXtraForm.cs
@@ -132,7 +132,10 @@ namespace PrizmMain.Forms.Settings
         {
             GridView v = sender as GridView;
             CurrentPipeMillSizeType = v.GetRow(e.RowHandle) as PipeMillSizeType;
-            CurrentPipeMillSizeType.PipeTests = new BindingList<PipeTest>();
+            if (CurrentPipeMillSizeType != null)
+            {
+                viewModel.UpdatePipeTests(CurrentPipeMillSizeType);
+            }
         }
 
         private void addPlateManufacturerButton_Click(object sender, EventArgs e)


### PR DESCRIPTION
On new typesize, inspection operations list isn't refreshed (cleared) at once #219
