### PR TITLE
Fixed bugs of modification Settings in user and permission grid

### DIFF
--- a/src/PrizmMainProject/Forms/Settings/SettingsViewModel.cs
+++ b/src/PrizmMainProject/Forms/Settings/SettingsViewModel.cs
@@ -384,6 +384,7 @@ namespace PrizmMain.Forms.Settings
            if (rolePerm != null)
            {
               role.Permissions.Remove(rolePerm);
+              ModifiableView.IsModified = true;
            }
 
         }
@@ -394,6 +395,7 @@ namespace PrizmMain.Forms.Settings
            if (rolePerm == null)
            {
               role.Permissions.Add(p);
+              ModifiableView.IsModified = true;
            }
         }
 
@@ -403,6 +405,7 @@ namespace PrizmMain.Forms.Settings
            if (userRole == null)
            {
               user.Roles.Add(role);
+              ModifiableView.IsModified = true;
            }
         }
 
@@ -412,6 +415,7 @@ namespace PrizmMain.Forms.Settings
            if (userRole != null)
            {
               user.Roles.Remove(userRole);
+              ModifiableView.IsModified = true;
            }
         }
 

--- a/src/PrizmMainProject/Forms/Settings/SettingsXtraForm.cs
+++ b/src/PrizmMainProject/Forms/Settings/SettingsXtraForm.cs
@@ -445,11 +445,9 @@ private void categoryGridView_InitNewRow(object sender, InitNewRowEventArgs e)
             {
                 case CollectionChangeAction.Add:
                     viewModel.AddPermissionToRole(role, p);
-                    IsModified = true;
                     break;
                 case CollectionChangeAction.Remove:
                     viewModel.RemovePermissionFromRole(role, p);
-                    IsModified = true;
                     break;
             }
         }
@@ -530,11 +528,9 @@ private void categoryGridView_InitNewRow(object sender, InitNewRowEventArgs e)
                     {
                         case CollectionChangeAction.Add:
                             viewModel.AddRoleToUser(role, user);
-                            IsModified = true;
                             break;
                         case CollectionChangeAction.Remove:
                             viewModel.RemoveRoleFromUser(role, user);
-                            IsModified = true;
                             break;
                     }
                 }


### PR DESCRIPTION
Move Modified flag from SettingsXtraForm to SettingsViewModel in the
part of the code, where object really changes

https://github.com/qlynn/prizm/issues/1
Settings form change status as modified after open tab page "users" #568
