### PR TITLE
Settings menu. Fix tabs switching

### DIFF
--- a/src/PrizmMainProject/Forms/MainChildForm/PrizmApplicationXtraForm.cs
+++ b/src/PrizmMainProject/Forms/MainChildForm/PrizmApplicationXtraForm.cs
@@ -179,8 +179,7 @@ namespace PrizmMain.Forms.MainChildForm
             }
             else
             {
-                Type formType = typeof(SettingsXtraForm);
-                var forms = childForms[formType.Name];
+                var forms = childForms[typeof(SettingsXtraForm).Name];
 
                 if (forms.Count > 0)
                 {

--- a/src/PrizmMainProject/Forms/MainChildForm/PrizmApplicationXtraForm.cs
+++ b/src/PrizmMainProject/Forms/MainChildForm/PrizmApplicationXtraForm.cs
@@ -177,6 +177,18 @@ namespace PrizmMain.Forms.MainChildForm
                 }
                 ShowChildForm(form);
             }
+            else
+            {
+                Type formType = typeof(SettingsXtraForm);
+                var forms = childForms[formType.Name];
+
+                if (forms.Count > 0)
+                {
+                    SettingsXtraForm f = (SettingsXtraForm)forms[0];
+                    f.settings.SelectedTabPage = f.settings.TabPages[page];
+                    f.Activate();
+                }      
+            }
         }
 
         private void barButtonItemNewPipe_ItemClick(object sender, ItemClickEventArgs e)


### PR DESCRIPTION
Fix tabs switching in child form when another one already been selected.

Settings: appropriate tab isn't activated #589
https://github.com/qlynn/prizm/issues/5
