### PR TITLE
add calling of session.Dispose(), commandManager.Dispose()

### DIFF
--- a/src/PrizmMainProject/Forms/Audit/AuditXtraForm.Designer.cs
+++ b/src/PrizmMainProject/Forms/Audit/AuditXtraForm.Designer.cs
@@ -379,6 +379,7 @@
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.None;
             this.Name = "AuditXtraForm";
             this.Text = "AuditXtraForm";
+            this.FormClosed += new System.Windows.Forms.FormClosedEventHandler(this.AuditXtraForm_FormClosed);
             this.Load += new System.EventHandler(this.AuditXtraForm_Load);
             ((System.ComponentModel.ISupportInitialize)(this.searchGroupLayout)).EndInit();
             this.searchGroupLayout.ResumeLayout(false);

--- a/src/PrizmMainProject/Forms/Audit/AuditXtraForm.cs
+++ b/src/PrizmMainProject/Forms/Audit/AuditXtraForm.cs
@@ -48,5 +48,12 @@ namespace Prizm.Main.Forms.Audit
             commandManager["Search"].Executor(viewModel.SearchCommand).AttachTo(search);
         }
 
+        private void AuditXtraForm_FormClosed(object sender, FormClosedEventArgs e)
+        {
+            commandManager.Dispose();
+            viewModel.Dispose();
+            viewModel = null;
+        }
+
     }
 }

--- a/src/PrizmMainProject/Forms/Component/NewEdit/ComponentNewEditXtraForm.Designer.cs
+++ b/src/PrizmMainProject/Forms/Component/NewEdit/ComponentNewEditXtraForm.Designer.cs
@@ -547,6 +547,7 @@
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.None;
             this.Name = "ComponentNewEditXtraForm";
             this.Text = " Комлектующее изделие";
+            this.FormClosed += new System.Windows.Forms.FormClosedEventHandler(this.ComponentNewEditXtraForm_FormClosed);
             this.Load += new System.EventHandler(this.ComponentNewEditXtraForm_Load);
             ((System.ComponentModel.ISupportInitialize)(this.componentNumber.Properties)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.newEditPipeLayout)).EndInit();

--- a/src/PrizmMainProject/Forms/Component/NewEdit/ComponentNewEditXtraForm.cs
+++ b/src/PrizmMainProject/Forms/Component/NewEdit/ComponentNewEditXtraForm.cs
@@ -249,5 +249,12 @@ namespace Prizm.Main.Forms.Component.NewEdit
             view.RemoveSelectedItem<InspectionTestResult>( e, viewModel.InspectionTestResults, (_) => _.IsNew());
             view.RefreshData();
         }
+
+        private void ComponentNewEditXtraForm_FormClosed(object sender, FormClosedEventArgs e)
+        {
+            commandManager.Dispose();
+            viewModel.Dispose();
+            viewModel = null;
+        }
     }
 }

--- a/src/PrizmMainProject/Forms/Joint/NewEdit/JointNewEditXtraForm.Designer.cs
+++ b/src/PrizmMainProject/Forms/Joint/NewEdit/JointNewEditXtraForm.Designer.cs
@@ -28,6 +28,7 @@
         /// </summary>
         private void InitializeComponent()
         {
+            this.components = new System.ComponentModel.Container();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(JointNewEditXtraForm));
             this.jointNumber = new DevExpress.XtraEditors.TextEdit();
             this.newJointLayoutControl = new DevExpress.XtraLayout.LayoutControl();
@@ -91,10 +92,10 @@
             this.saveButtonLayout = new DevExpress.XtraLayout.LayoutControlItem();
             this.saveButtonEmptySpace = new DevExpress.XtraLayout.EmptySpaceItem();
             this.saveAndCreateLayout = new DevExpress.XtraLayout.LayoutControlItem();
-            this.jointNewEditBindingSoure = new System.Windows.Forms.BindingSource();
-            this.pipelinePiecesBindingSource = new System.Windows.Forms.BindingSource();
-            this.inspectorsDataSource = new System.Windows.Forms.BindingSource();
-            this.weldersDataSource = new System.Windows.Forms.BindingSource();
+            this.jointNewEditBindingSoure = new System.Windows.Forms.BindingSource(this.components);
+            this.pipelinePiecesBindingSource = new System.Windows.Forms.BindingSource(this.components);
+            this.inspectorsDataSource = new System.Windows.Forms.BindingSource(this.components);
+            this.weldersDataSource = new System.Windows.Forms.BindingSource(this.components);
             ((System.ComponentModel.ISupportInitialize)(this.jointNumber.Properties)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.newJointLayoutControl)).BeginInit();
             this.newJointLayoutControl.SuspendLayout();
@@ -934,6 +935,7 @@
             this.Name = "JointNewEditXtraForm";
             this.ShowIcon = false;
             this.Text = "Стык";
+            this.FormClosed += new System.Windows.Forms.FormClosedEventHandler(this.JointNewEditXtraForm_FormClosed);
             this.Load += new System.EventHandler(this.JointNewEditXtraForm_Load);
             ((System.ComponentModel.ISupportInitialize)(this.jointNumber.Properties)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.newJointLayoutControl)).EndInit();

--- a/src/PrizmMainProject/Forms/Joint/NewEdit/JointNewEditXtraForm.cs
+++ b/src/PrizmMainProject/Forms/Joint/NewEdit/JointNewEditXtraForm.cs
@@ -368,5 +368,12 @@ namespace Prizm.Main.Forms.Joint.NewEdit
                 IsEditMode = false;
             }
         }
+
+        private void JointNewEditXtraForm_FormClosed(object sender, FormClosedEventArgs e)
+        {
+            commandManager.Dispose();
+            viewModel.Dispose();
+            viewModel = null;
+        }
     }
 }

--- a/src/PrizmMainProject/Forms/Joint/Search/JointSearchViewModel.cs
+++ b/src/PrizmMainProject/Forms/Joint/Search/JointSearchViewModel.cs
@@ -15,13 +15,15 @@ using Construction = Prizm.Domain.Entity.Construction;
 
 namespace Prizm.Main.Forms.Joint.Search
 {
-    public class JointSearchViewModel : ViewModelBase
+    public class JointSearchViewModel : ViewModelBase, IDisposable
     {
         private readonly JointSearchCommand searchCommand;
+        private readonly IJointRepository repo;
 
         [Inject]
         public JointSearchViewModel(IJointRepository repo)
         {
+            this.repo = repo;
             searchCommand = ViewModelSource.Create(() => new JointSearchCommand(this, repo));
         }
 
@@ -114,6 +116,11 @@ namespace Prizm.Main.Forms.Joint.Search
         public ICommand SearchCommand
         {
             get { return searchCommand; }
+        }
+
+        public void Dispose()
+        {
+            repo.Dispose();
         }
     }
 }

--- a/src/PrizmMainProject/Forms/Joint/Search/JointSearchXtraForm.Designer.cs
+++ b/src/PrizmMainProject/Forms/Joint/Search/JointSearchXtraForm.Designer.cs
@@ -475,6 +475,7 @@
             this.Name = "JointSearchXtraForm";
             this.Padding = new System.Windows.Forms.Padding(2);
             this.Text = "Поиск стыков";
+            this.FormClosed += new System.Windows.Forms.FormClosedEventHandler(this.JointSearchXtraForm_FormClosed);
             this.Load += new System.EventHandler(this.JointSearchXtraForm_Load);
             ((System.ComponentModel.ISupportInitialize)(this.extraJointButton)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.searchLayoutControl)).EndInit();

--- a/src/PrizmMainProject/Forms/Joint/Search/JointSearchXtraForm.cs
+++ b/src/PrizmMainProject/Forms/Joint/Search/JointSearchXtraForm.cs
@@ -113,5 +113,12 @@ namespace Prizm.Main.Forms.Joint.Search
                 parent.CreateChildForm(typeof(JointNewEditXtraForm), new ConstructorArgument("jointId", id));
             }
         }
+
+        private void JointSearchXtraForm_FormClosed(object sender, FormClosedEventArgs e)
+        {
+            commandManager.Dispose();
+            viewModel.Dispose();
+            viewModel = null;
+        }
     }
 }

--- a/src/PrizmMainProject/Forms/Part/Search/PartSearchViewModel.cs
+++ b/src/PrizmMainProject/Forms/Part/Search/PartSearchViewModel.cs
@@ -78,7 +78,7 @@ namespace Prizm.Main.Forms.InspectionParts.Search
 
         public void Dispose()
         {
-
+            session.Dispose();
         }
 
         #endregion

--- a/src/PrizmMainProject/Forms/Part/Search/PartSearchXtraForm.Designer.cs
+++ b/src/PrizmMainProject/Forms/Part/Search/PartSearchXtraForm.Designer.cs
@@ -251,6 +251,7 @@
             this.Controls.Add(this.mainLayoutControl);
             this.Name = "PartSearchXtraForm";
             this.Text = "Строительство - поиск компонентов";
+            this.FormClosed += new System.Windows.Forms.FormClosedEventHandler(this.PartSearchXtraForm_FormClosed);
             this.Load += new System.EventHandler(this.PartsSearchXtraForm_Load);
             ((System.ComponentModel.ISupportInitialize)(this.mainLayoutControl)).EndInit();
             this.mainLayoutControl.ResumeLayout(false);

--- a/src/PrizmMainProject/Forms/Part/Search/PartSearchXtraForm.cs
+++ b/src/PrizmMainProject/Forms/Part/Search/PartSearchXtraForm.cs
@@ -122,5 +122,12 @@ namespace Prizm.Main.Forms.InspectionParts.Search
                 partsView_DoubleClick(sender, e);
             }
         }
+
+        private void PartSearchXtraForm_FormClosed(object sender, FormClosedEventArgs e)
+        {
+            commandManager.Dispose();
+            viewModel.Dispose();
+            viewModel = null;
+        }
     }
 }

--- a/src/PrizmMainProject/Forms/PipeMill/NewEdit/MillPipeNewEditXtraForm.Designer.cs
+++ b/src/PrizmMainProject/Forms/PipeMill/NewEdit/MillPipeNewEditXtraForm.Designer.cs
@@ -28,17 +28,18 @@
         /// </summary>
         private void InitializeComponent()
         {
+            this.components = new System.ComponentModel.Container();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(MillPipeNewEditXtraForm));
             this.weldersListGridView = new DevExpress.XtraGrid.Views.Grid.GridView();
             this.firstNameGridColumn = new DevExpress.XtraGrid.Columns.GridColumn();
             this.lastNameGridColumn = new DevExpress.XtraGrid.Columns.GridColumn();
             this.weldingHistory = new DevExpress.XtraGrid.GridControl();
-            this.weldBindingSource = new System.Windows.Forms.BindingSource();
+            this.weldBindingSource = new System.Windows.Forms.BindingSource(this.components);
             this.weldingHistoryGridView = new DevExpress.XtraGrid.Views.Grid.GridView();
             this.weldingDateGridColumn = new DevExpress.XtraGrid.Columns.GridColumn();
             this.weldersGridColumn = new DevExpress.XtraGrid.Columns.GridColumn();
             this.repositoryItemPopupWelders = new DevExpress.XtraEditors.Repository.RepositoryItemPopupContainerEdit();
-            this.weldersDataSource = new System.Windows.Forms.BindingSource();
+            this.weldersDataSource = new System.Windows.Forms.BindingSource(this.components);
             this.pipe = new DevExpress.XtraTab.XtraTabControl();
             this.generalParametersPage = new DevExpress.XtraTab.XtraTabPage();
             this.pipeGeneralParametersLayout = new DevExpress.XtraLayout.LayoutControl();
@@ -50,7 +51,7 @@
             this.destination = new DevExpress.XtraEditors.TextEdit();
             this.railcarNumber = new DevExpress.XtraEditors.TextEdit();
             this.coatingHistory = new DevExpress.XtraGrid.GridControl();
-            this.coatDataSource = new System.Windows.Forms.BindingSource();
+            this.coatDataSource = new System.Windows.Forms.BindingSource(this.components);
             this.coatingHistoryGridView = new DevExpress.XtraGrid.Views.Grid.GridView();
             this.coatingDateGridColumn = new DevExpress.XtraGrid.Columns.GridColumn();
             this.coatingTypeGridColumn = new DevExpress.XtraGrid.Columns.GridColumn();
@@ -88,7 +89,7 @@
             this.inspectionPage = new DevExpress.XtraTab.XtraTabPage();
             this.generalInspectionsLayout = new DevExpress.XtraLayout.LayoutControl();
             this.inspections = new DevExpress.XtraGrid.GridControl();
-            this.inspectionOperation = new System.Windows.Forms.BindingSource();
+            this.inspectionOperation = new System.Windows.Forms.BindingSource(this.components);
             this.inspectionsGridView = new DevExpress.XtraGrid.Views.Grid.GridView();
             this.inspectionNameGridColumn = new DevExpress.XtraGrid.Columns.GridColumn();
             this.expectedResultGridColumn = new DevExpress.XtraGrid.Columns.GridColumn();
@@ -137,9 +138,9 @@
             this.ordersLayout = new DevExpress.XtraLayout.LayoutControlItem();
             this.pipeParametersLayout = new DevExpress.XtraLayout.LayoutControlItem();
             this.certificateEmptySpace = new DevExpress.XtraLayout.EmptySpaceItem();
-            this.weldingDs = new System.Windows.Forms.BindingSource();
-            this.pipeNewEditBindingSource = new System.Windows.Forms.BindingSource();
-            this.inspectorsDataSource = new System.Windows.Forms.BindingSource();
+            this.weldingDs = new System.Windows.Forms.BindingSource(this.components);
+            this.pipeNewEditBindingSource = new System.Windows.Forms.BindingSource(this.components);
+            this.inspectorsDataSource = new System.Windows.Forms.BindingSource(this.components);
             ((System.ComponentModel.ISupportInitialize)(this.weldersListGridView)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.weldingHistory)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.weldBindingSource)).BeginInit();
@@ -279,7 +280,7 @@
             // 
             // weldBindingSource
             // 
-            this.weldBindingSource.DataSource = typeof(Domain.Entity.Mill.Weld);
+            this.weldBindingSource.DataSource = typeof(Prizm.Domain.Entity.Mill.Weld);
             // 
             // weldingHistoryGridView
             // 
@@ -1502,6 +1503,7 @@
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.None;
             this.Name = "MillPipeNewEditXtraForm";
             this.Text = "Труба";
+            this.FormClosed += new System.Windows.Forms.FormClosedEventHandler(this.MillPipeNewEditXtraForm_FormClosed);
             this.Load += new System.EventHandler(this.MillPipeNewEditXtraForm_Load);
             ((System.ComponentModel.ISupportInitialize)(this.weldersListGridView)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.weldingHistory)).EndInit();

--- a/src/PrizmMainProject/Forms/PipeMill/NewEdit/MillPipeNewEditXtraForm.cs
+++ b/src/PrizmMainProject/Forms/PipeMill/NewEdit/MillPipeNewEditXtraForm.cs
@@ -656,6 +656,12 @@ namespace Prizm.Main.Forms.PipeMill.NewEdit
             ordersLookUp.Properties.DataSource = viewModel.PurchaseOrders;
         }
 
-
+        private void MillPipeNewEditXtraForm_FormClosed(object sender, FormClosedEventArgs e)
+        {
+            commandManager.Dispose();
+            viewModel.Dispose();
+            viewModel = null;
+        }
+    
     }
 }

--- a/src/PrizmMainProject/Forms/PipeMill/Purchase/PurchaseOrderXtraForm.Designer.cs
+++ b/src/PrizmMainProject/Forms/PipeMill/Purchase/PurchaseOrderXtraForm.Designer.cs
@@ -235,6 +235,7 @@
             this.Name = "PurchaseOrderXtraForm";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Text = "Наряд-заказ";
+            this.FormClosed += new System.Windows.Forms.FormClosedEventHandler(this.PurchaseOrderXtraForm_FormClosed);
             this.Load += new System.EventHandler(this.PurchaseOrderXtraForm_Load);
             ((System.ComponentModel.ISupportInitialize)(this.purchaseOrderLayout)).EndInit();
             this.purchaseOrderLayout.ResumeLayout(false);

--- a/src/PrizmMainProject/Forms/PipeMill/Purchase/PurchaseOrderXtraForm.cs
+++ b/src/PrizmMainProject/Forms/PipeMill/Purchase/PurchaseOrderXtraForm.cs
@@ -64,5 +64,11 @@ namespace Prizm.Main.Forms.PipeMill
         {
             number.Properties.MaxLength = LengthLimit.MaxPurchaseOrderNumber;
         }
+
+        private void PurchaseOrderXtraForm_FormClosed(object sender, FormClosedEventArgs e)
+        {
+            viewModel.Dispose();
+            viewModel = null;
+        }
     }
 }

--- a/src/PrizmMainProject/Forms/PipeMill/Search/MillPipeSearchXtraForm.Designer.cs
+++ b/src/PrizmMainProject/Forms/PipeMill/Search/MillPipeSearchXtraForm.Designer.cs
@@ -561,6 +561,7 @@
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.None;
             this.Name = "MillPipeSearchXtraForm";
             this.Text = "Поиск труб";
+            this.FormClosed += new System.Windows.Forms.FormClosedEventHandler(this.MillPipeSearchXtraForm_FormClosed);
             this.Load += new System.EventHandler(this.MillPipeSearchXtraForm_Load);
             ((System.ComponentModel.ISupportInitialize)(this.extraButton)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.PipeSearchLayoutControl)).EndInit();

--- a/src/PrizmMainProject/Forms/PipeMill/Search/MillPipeSearchXtraForm.cs
+++ b/src/PrizmMainProject/Forms/PipeMill/Search/MillPipeSearchXtraForm.cs
@@ -112,5 +112,12 @@ namespace Prizm.Main.Forms.PipeMill.Search
                 }
             }
         }
+
+        private void MillPipeSearchXtraForm_FormClosed(object sender, FormClosedEventArgs e)
+        {
+            commandManager.Dispose();
+            viewModel.Dispose();
+            viewModel = null;
+        }
     }
 }

--- a/src/PrizmMainProject/Forms/Railcar/Search/RailcarSearchXtraForm.Designer.cs
+++ b/src/PrizmMainProject/Forms/Railcar/Search/RailcarSearchXtraForm.Designer.cs
@@ -28,6 +28,7 @@
         /// </summary>
         private void InitializeComponent()
         {
+            this.components = new System.ComponentModel.Container();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(RailcarSearchXtraForm));
             DevExpress.Utils.SerializableAppearanceObject serializableAppearanceObject1 = new DevExpress.Utils.SerializableAppearanceObject();
             DevExpress.Utils.SerializableAppearanceObject serializableAppearanceObject2 = new DevExpress.Utils.SerializableAppearanceObject();
@@ -38,7 +39,7 @@
             this.shipButton = new DevExpress.XtraEditors.Repository.RepositoryItemButtonEdit();
             this.unshipButton = new DevExpress.XtraEditors.Repository.RepositoryItemButtonEdit();
             this.railcarList = new DevExpress.XtraGrid.GridControl();
-            this.bindingSource = new System.Windows.Forms.BindingSource();
+            this.bindingSource = new System.Windows.Forms.BindingSource(this.components);
             this.railcarListView = new DevExpress.XtraGrid.Views.Grid.GridView();
             this.editGridColumn = new DevExpress.XtraGrid.Columns.GridColumn();
             this.isShipped = new DevExpress.XtraGrid.Columns.GridColumn();
@@ -429,6 +430,7 @@
             this.Name = "RailcarSearchXtraForm";
             this.Padding = new System.Windows.Forms.Padding(5);
             this.Text = "Поиск разрешений на отгрузку";
+            this.FormClosed += new System.Windows.Forms.FormClosedEventHandler(this.RailcarSearchXtraForm_FormClosed);
             this.Load += new System.EventHandler(this.RailcarSearchXtraForm_Load);
             ((System.ComponentModel.ISupportInitialize)(this.openRailcarButton)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.shipButton)).EndInit();

--- a/src/PrizmMainProject/Forms/Railcar/Search/RailcarSearchXtraForm.cs
+++ b/src/PrizmMainProject/Forms/Railcar/Search/RailcarSearchXtraForm.cs
@@ -107,5 +107,12 @@ namespace Prizm.Main.Forms.Railcar.Search
             }
         }
 
+        private void RailcarSearchXtraForm_FormClosed(object sender, FormClosedEventArgs e)
+        {
+            commandManager.Dispose();
+            viewModel.Dispose();
+            viewModel = null;
+        }
+
     }
 }

--- a/src/PrizmMainProject/Forms/Reports/Construction/ConstructionReportsXtraForm.Designer.cs
+++ b/src/PrizmMainProject/Forms/Reports/Construction/ConstructionReportsXtraForm.Designer.cs
@@ -399,6 +399,7 @@
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.None;
             this.Name = "ConstructionReportsXtraForm";
             this.Text = "Строительство - отчет";
+            this.FormClosed += new System.Windows.Forms.FormClosedEventHandler(this.ConstructionReportsXtraForm_FormClosed);
             this.Load += new System.EventHandler(this.ConstructionReportsXtraForm_Load);
             ((System.ComponentModel.ISupportInitialize)(this.reportType.Properties)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.generalLayout)).EndInit();

--- a/src/PrizmMainProject/Forms/Reports/Construction/ConstructionReportsXtraForm.cs
+++ b/src/PrizmMainProject/Forms/Reports/Construction/ConstructionReportsXtraForm.cs
@@ -126,5 +126,11 @@ namespace Prizm.Main.Forms.Reports.Construction
         {
             RefreshTypes();
         }
+
+        private void ConstructionReportsXtraForm_FormClosed(object sender, FormClosedEventArgs e)
+        {
+            commandManager.Dispose();
+            viewModel = null;
+        }
     }
 }

--- a/src/PrizmMainProject/Forms/Reports/Incoming/InspectionReportsXtraForm.Designer.cs
+++ b/src/PrizmMainProject/Forms/Reports/Incoming/InspectionReportsXtraForm.Designer.cs
@@ -43,9 +43,9 @@
             this.incomingInspectionDateLayout = new DevExpress.XtraLayout.LayoutControlItem();
             this.endDateLayout = new DevExpress.XtraLayout.LayoutControlItem();
             this.createButtonLayout = new DevExpress.XtraLayout.LayoutControlItem();
-            this.DateEmptySpace = new DevExpress.XtraLayout.EmptySpaceItem();
             this.labelEmptySpaceItem = new DevExpress.XtraLayout.EmptySpaceItem();
             this.previewButtonLayout = new DevExpress.XtraLayout.LayoutControlItem();
+            this.DateEmptySpace = new DevExpress.XtraLayout.EmptySpaceItem();
             this.previewReportLayoutGroup = new DevExpress.XtraLayout.LayoutControlGroup();
             this.previewLayout = new DevExpress.XtraLayout.LayoutControlItem();
             this.inspectionReportsBindingSource = new System.Windows.Forms.BindingSource(this.components);
@@ -61,9 +61,9 @@
             ((System.ComponentModel.ISupportInitialize)(this.incomingInspectionDateLayout)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.endDateLayout)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.createButtonLayout)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.DateEmptySpace)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.labelEmptySpaceItem)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.previewButtonLayout)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.DateEmptySpace)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.previewReportLayoutGroup)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.previewLayout)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.inspectionReportsBindingSource)).BeginInit();
@@ -230,16 +230,6 @@
             this.createButtonLayout.TextToControlDistance = 0;
             this.createButtonLayout.TextVisible = false;
             // 
-            // DateEmptySpace
-            // 
-            this.DateEmptySpace.AllowHotTrack = false;
-            this.DateEmptySpace.CustomizationFormText = "DateEmptySpace";
-            this.DateEmptySpace.Location = new System.Drawing.Point(449, 0);
-            this.DateEmptySpace.Name = "DateEmptySpace";
-            this.DateEmptySpace.Size = new System.Drawing.Size(447, 41);
-            this.DateEmptySpace.Text = "DateEmptySpace";
-            this.DateEmptySpace.TextSize = new System.Drawing.Size(0, 0);
-            // 
             // labelEmptySpaceItem
             // 
             this.labelEmptySpaceItem.AllowHotTrack = false;
@@ -264,6 +254,16 @@
             this.previewButtonLayout.TextSize = new System.Drawing.Size(0, 0);
             this.previewButtonLayout.TextToControlDistance = 0;
             this.previewButtonLayout.TextVisible = false;
+            // 
+            // DateEmptySpace
+            // 
+            this.DateEmptySpace.AllowHotTrack = false;
+            this.DateEmptySpace.CustomizationFormText = "DateEmptySpace";
+            this.DateEmptySpace.Location = new System.Drawing.Point(449, 0);
+            this.DateEmptySpace.Name = "DateEmptySpace";
+            this.DateEmptySpace.Size = new System.Drawing.Size(447, 41);
+            this.DateEmptySpace.Text = "DateEmptySpace";
+            this.DateEmptySpace.TextSize = new System.Drawing.Size(0, 0);
             // 
             // previewReportLayoutGroup
             // 
@@ -298,6 +298,7 @@
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.None;
             this.Name = "InspectionReportsXtraForm";
             this.Text = "Отчет";
+            this.FormClosed += new System.Windows.Forms.FormClosedEventHandler(this.InspectionReportsXtraForm_FormClosed);
             this.Load += new System.EventHandler(this.InspectionReportsXtraForm_Load);
             ((System.ComponentModel.ISupportInitialize)(this.generalLayout)).EndInit();
             this.generalLayout.ResumeLayout(false);
@@ -311,9 +312,9 @@
             ((System.ComponentModel.ISupportInitialize)(this.incomingInspectionDateLayout)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.endDateLayout)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.createButtonLayout)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.DateEmptySpace)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.labelEmptySpaceItem)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.previewButtonLayout)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.DateEmptySpace)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.previewReportLayoutGroup)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.previewLayout)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.inspectionReportsBindingSource)).EndInit();

--- a/src/PrizmMainProject/Forms/Reports/Incoming/InspectionReportsXtraForm.cs
+++ b/src/PrizmMainProject/Forms/Reports/Incoming/InspectionReportsXtraForm.cs
@@ -37,5 +37,11 @@ namespace Prizm.Main.Forms.Reports.Incoming
             viewModel.StartDate = DateTime.Now.Date;
             viewModel.EndDate = DateTime.Now.Date;
         }
+
+        private void InspectionReportsXtraForm_FormClosed(object sender, System.Windows.Forms.FormClosedEventArgs e)
+        {
+            commandManager.Dispose();
+            viewModel = null;
+        }
     }
 }

--- a/src/PrizmMainProject/Forms/Reports/Mill/MillReportsXtraForm.Designer.cs
+++ b/src/PrizmMainProject/Forms/Reports/Mill/MillReportsXtraForm.Designer.cs
@@ -465,6 +465,7 @@
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.None;
             this.Name = "MillReportsXtraForm";
             this.Text = "Отчет";
+            this.FormClosed += new System.Windows.Forms.FormClosedEventHandler(this.MillReportsXtraForm_FormClosed);
             this.Load += new System.EventHandler(this.MillReportsXtraForm_Load);
             ((System.ComponentModel.ISupportInitialize)(this.generalReportLayout)).EndInit();
             this.generalReportLayout.ResumeLayout(false);

--- a/src/PrizmMainProject/Forms/Reports/Mill/MillReportsXtraForm.cs
+++ b/src/PrizmMainProject/Forms/Reports/Mill/MillReportsXtraForm.cs
@@ -104,6 +104,10 @@ namespace Prizm.Main.Forms.Reports.Mill
             viewModel.SearchStatuses = statusList;
         }
 
-
+        private void MillReportsXtraForm_FormClosed(object sender, System.Windows.Forms.FormClosedEventArgs e)
+        {
+            commandManager.Dispose();
+            viewModel = null;
+        }
     }
 }

--- a/src/PrizmMainProject/Forms/Spool/SpoolsXtraForm.Designer.cs
+++ b/src/PrizmMainProject/Forms/Spool/SpoolsXtraForm.Designer.cs
@@ -567,6 +567,7 @@
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.None;
             this.Name = "SpoolsXtraForm";
             this.Text = "Создание катушки";
+            this.FormClosed += new System.Windows.Forms.FormClosedEventHandler(this.SpoolsXtraForm_FormClosed);
             this.Load += new System.EventHandler(this.SpoolsXtraForm_Load);
             ((System.ComponentModel.ISupportInitialize)(this.mainLayoutControl)).EndInit();
             this.mainLayoutControl.ResumeLayout(false);

--- a/src/PrizmMainProject/Forms/Spool/SpoolsXtraForm.cs
+++ b/src/PrizmMainProject/Forms/Spool/SpoolsXtraForm.cs
@@ -184,5 +184,12 @@ namespace Prizm.Main.Forms.Spool
             IList<Inspector> inspectors = e.Value as IList<Inspector>;
             e.DisplayText = viewModel.FormatInspectorList(inspectors);
         }
+
+        private void SpoolsXtraForm_FormClosed(object sender, FormClosedEventArgs e)
+        {
+            commandManager.Dispose();
+            viewModel.Dispose();
+            viewModel = null;
+        }
     }
 }


### PR DESCRIPTION
methods into FormClosed handler for memory leak prevent

"When form is closing, the dependencies
 should be disposed to avoid memory leaks." #610
