### PR TITLE
Implement attaching files functionality

### DIFF
--- a/src/PrizmMainProject/Forms/ExternalFile/ExternalFilesXtraForm.cs
+++ b/src/PrizmMainProject/Forms/ExternalFile/ExternalFilesXtraForm.cs
@@ -34,7 +34,8 @@ namespace Prizm.Main.Forms.ExternalFile
         {
             Guid newNameId = Guid.NewGuid();
             OpenFileDialog openFileDlg = new OpenFileDialog();
-            openFileDlg.InitialDirectory = Directory.GetCurrentDirectory();
+            // TODO Save new files position to user settings.
+            openFileDlg.InitialDirectory = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
             if (openFileDlg.ShowDialog() == DialogResult.OK)
             {
                 FileInfo fileInfo = new FileInfo(openFileDlg.FileName);
@@ -61,6 +62,8 @@ namespace Prizm.Main.Forms.ExternalFile
                 viewModel.SelectedFile = selectedFile;
                 SaveFileDialog saveFileDlg = new SaveFileDialog();
                 saveFileDlg.FileName = selectedFile.FileName;
+                // TODO Save new files position to user settings.
+                saveFileDlg.InitialDirectory = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
                 if (saveFileDlg.ShowDialog() == DialogResult.OK)
                 {
                     viewModel.SelectedPath = saveFileDlg.FileName;


### PR DESCRIPTION
Made My documents default directory
Implement attaching files functionality #651
FilesToAttach is a temporary folder that contains files before linked entity is saved. For example : user selects files that are located on usb device - files are copied to FilesToAttach folder. User ejects USB device - files are not lost. User saves pipe/spool/etc - files are copied from FilesToAttach to Attachments folder, FilesToAttach folder is removed.
