### PR TITLE
Pipe search, part search - exception on double click on empty grid

### DIFF
--- a/src/PrizmMainProject/Forms/Parts/Search/PartSearchXtraForm.cs
+++ b/src/PrizmMainProject/Forms/Parts/Search/PartSearchXtraForm.cs
@@ -83,7 +83,7 @@ namespace Prizm.Main.Forms.Parts.Search
         private void partsView_DoubleClick(object sender, EventArgs e)
         {
             int selectedPart = partsView.GetFocusedDataSourceRowIndex();
-            if (selectedPart > 0)
+            if (selectedPart >= 0)
             {
                 var parent = this.MdiParent as PrizmApplicationXtraForm;
                 switch (viewModel.Parts[selectedPart].Type.Value)

--- a/src/PrizmMainProject/Forms/Parts/Search/PartSearchXtraForm.cs
+++ b/src/PrizmMainProject/Forms/Parts/Search/PartSearchXtraForm.cs
@@ -83,36 +83,37 @@ namespace Prizm.Main.Forms.Parts.Search
         private void partsView_DoubleClick(object sender, EventArgs e)
         {
             int selectedPart = partsView.GetFocusedDataSourceRowIndex();
-
-            var parent = this.MdiParent as PrizmApplicationXtraForm;
-            switch (viewModel.Parts[selectedPart].Type.Value)
+            if (selectedPart > 0)
             {
-                case PartType.Component:
-                    {
-                        parent.CreateChildForm(
-                            typeof(ComponentNewEditXtraForm),
-                            new ConstructorArgument(
-                                "id",
+                var parent = this.MdiParent as PrizmApplicationXtraForm;
+                switch (viewModel.Parts[selectedPart].Type.Value)
+                {
+                    case PartType.Component:
+                        {
+                            parent.CreateChildForm(
+                                typeof(ComponentNewEditXtraForm),
+                                new ConstructorArgument(
+                                    "id",
+                                    viewModel.Parts[selectedPart].Id));
+                        } break;
+                    case PartType.Pipe:
+                        {
+                            parent.CreateChildForm
+                                (typeof(MillPipeNewEditXtraForm),
+                                new ConstructorArgument("id",
                                 viewModel.Parts[selectedPart].Id));
-                    } break;
-                case PartType.Pipe:
-                    {
-                        parent.CreateChildForm
-                            (typeof(MillPipeNewEditXtraForm),
-                            new ConstructorArgument("id",
-                            viewModel.Parts[selectedPart].Id));
-                    } break;
-                case PartType.Spool:
-                    {
-                        parent.CreateChildForm(
-                            typeof(SpoolsXtraForm),
-                            new ConstructorArgument("id",
-                                viewModel.Parts[selectedPart].Id)
-                            );
-                    } break;
-                default: break;
+                        } break;
+                    case PartType.Spool:
+                        {
+                            parent.CreateChildForm(
+                                typeof(SpoolsXtraForm),
+                                new ConstructorArgument("id",
+                                    viewModel.Parts[selectedPart].Id)
+                                );
+                        } break;
+                    default: break;
+                }
             }
-
         }
 
         private void partsView_KeyDown(object sender, KeyEventArgs e)

--- a/src/PrizmMainProject/Forms/PipeMill/Search/MillPipeSearchXtraForm.cs
+++ b/src/PrizmMainProject/Forms/PipeMill/Search/MillPipeSearchXtraForm.cs
@@ -63,7 +63,7 @@ namespace Prizm.Main.Forms.PipeMill.Search
         private void pipeRepositoryButtonEdit_Click(object sender, System.EventArgs e)
         {
             int selectedPipe = pipesSearchResultView.GetFocusedDataSourceRowIndex();
-            if (selectedPipe > 0)
+            if (selectedPipe >= 0)
             {
                 var parent = this.MdiParent as PrizmApplicationXtraForm;
 

--- a/src/PrizmMainProject/Forms/PipeMill/Search/MillPipeSearchXtraForm.cs
+++ b/src/PrizmMainProject/Forms/PipeMill/Search/MillPipeSearchXtraForm.cs
@@ -63,14 +63,16 @@ namespace Prizm.Main.Forms.PipeMill.Search
         private void pipeRepositoryButtonEdit_Click(object sender, System.EventArgs e)
         {
             int selectedPipe = pipesSearchResultView.GetFocusedDataSourceRowIndex();
+            if (selectedPipe > 0)
+            {
+                var parent = this.MdiParent as PrizmApplicationXtraForm;
 
-            var parent = this.MdiParent as PrizmApplicationXtraForm;
-
-            parent.CreateChildForm(
-                    typeof(MillPipeNewEditXtraForm),
-                    new ConstructorArgument(
-                        "id",
-                        viewModel.Pipes[selectedPipe].Id));
+                parent.CreateChildForm(
+                        typeof(MillPipeNewEditXtraForm),
+                        new ConstructorArgument(
+                            "id",
+                            viewModel.Pipes[selectedPipe].Id));
+            }
         }
 
         private void pipesSearchResultView_DoubleClick(object sender, EventArgs e)


### PR DESCRIPTION
Pipe search, part search - exception on double click on empty grid #748
