### PR TITLE
Deactivated joint does not free it's elements.

### DIFF
--- a/src/PrizmMainProject/Forms/Joint/NewEdit/JointDeactivationCommand.cs
+++ b/src/PrizmMainProject/Forms/Joint/NewEdit/JointDeactivationCommand.cs
@@ -33,8 +33,11 @@ namespace Prizm.Main.Forms.Joint.NewEdit
             if (notify.ShowYesNo(
                    Resources.DLG_JOINT_DEACTIVATION,
                    Resources.DLG_JOINT_DEACTIVATION_HEADER))
-            {
-                viewModel.SaveJointCommand.Execute();
+            {              
+                repo.BeginTransaction();
+                repo.RepoJoint.Save(viewModel.Joint);
+                repo.Commit();
+                repo.RepoJoint.Evict(viewModel.Joint);
             }
             else
             {

--- a/src/PrizmMainProject/Forms/Joint/NewEdit/JointNewEditViewModel.cs
+++ b/src/PrizmMainProject/Forms/Joint/NewEdit/JointNewEditViewModel.cs
@@ -676,10 +676,13 @@ namespace Prizm.Main.Forms.Joint.NewEdit
 
                 if (part is construction.Component)
                 {
-                    connector.Diameter = ((construction.Component)part)
-                        .Connectors
-                        .First<Connector>(x => x.Joint != null && x.Joint.Id == this.Joint.Id)
-                        .Diameter;
+                    if (Joint.IsActive)
+                    {
+                        connector.Diameter = ((construction.Component)part)
+                            .Connectors
+                            .First<Connector>(x => x.Joint != null && x.Joint.Id == this.Joint.Id)
+                            .Diameter;
+                    }
                 }
                 else if (part is Pipe)
                 {

--- a/src/PrizmMainProject/Forms/Joint/NewEdit/JointNewEditXtraForm.cs
+++ b/src/PrizmMainProject/Forms/Joint/NewEdit/JointNewEditXtraForm.cs
@@ -380,6 +380,8 @@ namespace Prizm.Main.Forms.Joint.NewEdit
                 viewModel.JointDeactivationCommand.Execute();
                 IsEditMode = false;
             }
+            commandManager["Save"].RefreshState();
+            commandManager["SaveAndNew"].RefreshState();
         }
 
         private void JointNewEditXtraForm_FormClosed(object sender, FormClosedEventArgs e)


### PR DESCRIPTION
Issue #833
Disconnection functionality was already implemented by dsyd and is used
everytime joint is opened. So only saving disconnected joint was done
