### PR TITLE
Not all field names are localized :added localization for part types, RN status, construction report types and hardcoded labels,joint status

### DIFF
--- a/install/Lang/Translations/Strings.en-EN.txt
+++ b/install/Lang/Translations/Strings.en-EN.txt
@@ -1977,3 +1977,21 @@ Notification_ExpiredCertificate_Critical=Certificate's date is expired
 
 ;Сообщение о приближении окончания срока: Заканчивается срок сертификата
 Notification_ExpiredCertificate_Warning=Certificate's date will be expired soon
+
+;Тип рабочей станции. Неопределен
+WorkstationType_Undefined=Undefined
+
+;Тип рабочей станции. Главный
+WorkstationType_Master=Master
+
+;Тип рабочей станции. Завод
+WorkstationType_Mill=Mill
+
+;Тип рабочей станции. Строительство
+WorkstationType_Construction=Construction
+
+;Тип отчета. По трассировке
+ConstractionReport_ReportTypeTracingReport=Tracing report
+
+;Тип отчета. По использованным изделиям
+ConstractionReport_ReportTypeUsedProductReport=By used products

--- a/install/Lang/Translations/Strings.en-EN.txt
+++ b/install/Lang/Translations/Strings.en-EN.txt
@@ -1995,3 +1995,6 @@ ConstractionReport_ReportTypeTracingReport=Tracing report
 
 ;Тип отчета. По использованным изделиям
 ConstractionReport_ReportTypeUsedProductReport=By used products
+
+;Отчеты на строительстве.Текст информационного поля отчета по использованным изделиям
+ConstractionReport_TracingReportInfoLabelText = This report type contains all welded elements located between selected points regardless of their connectivity

--- a/src/PrizmMainProject/Forms/Joint/NewEdit/JointCutCommand.cs
+++ b/src/PrizmMainProject/Forms/Joint/NewEdit/JointCutCommand.cs
@@ -46,7 +46,7 @@ namespace Prizm.Main.Forms.Joint.NewEdit
                     viewModel.Joint.FirstElement = null;
                     viewModel.Joint.SecondElement = null;
 
-                    viewModel.JointConstructionStatus.Value = Domain.Entity.Construction.JointStatus.Withdrawn;
+                    viewModel.JointConstructionStatus = Domain.Entity.Construction.JointStatus.Withdrawn;
 
                     repo.BeginTransaction();
                     repo.RepoJoint.SaveOrUpdate(viewModel.Joint);

--- a/src/PrizmMainProject/Forms/Joint/NewEdit/JointNewEditViewModel.cs
+++ b/src/PrizmMainProject/Forms/Joint/NewEdit/JointNewEditViewModel.cs
@@ -41,7 +41,7 @@ namespace Prizm.Main.Forms.Joint.NewEdit
         private DataTable pieces;
         private BindingList<JointTestResult> jointTestResults;
         private BindingList<JointWeldResult> jointWeldResults;
-        private EnumWrapper<JointStatus> jointStatus = new EnumWrapper<JointStatus>(JointStatus.Welded);
+        private JointStatus jointStatus = JointStatus.Welded;
 
         private PartData firstElement;
         private PartData secondElement;
@@ -393,7 +393,7 @@ namespace Prizm.Main.Forms.Joint.NewEdit
             return PartDataList != null ? PartDataList.FirstOrDefault<PartData>(x => x.Id == id) : null;
         }
 
-        public EnumWrapper<JointStatus> JointConstructionStatus
+        public JointStatus JointConstructionStatus
         {
             get 
             {
@@ -406,16 +406,16 @@ namespace Prizm.Main.Forms.Joint.NewEdit
                     Joint.Status = JointStatus.Withdrawn;
                 }
 
-                jointStatus.Value = Joint.Status;
+                jointStatus = Joint.Status;
 
                 return jointStatus; 
             }
             set 
             {
-                if (value.Value != Joint.Status)
+                if (value != Joint.Status)
                 {
                     jointStatus = value;
-                    Joint.Status = value.Value;
+                    Joint.Status = value;
                     RaisePropertyChanged("JointConstructionStatus");
                 }
             }
@@ -773,7 +773,7 @@ namespace Prizm.Main.Forms.Joint.NewEdit
             Joint.FirstElement = new PartData();
             Joint.SecondElement = new PartData();
             this.Joint.IsActive = true;
-            this.Joint.Status = jointStatus.Value;
+            this.Joint.Status = jointStatus;
             this.JointTestResults = new BindingList<JointTestResult>();
             if (repoConstruction.RepoJointOperation.GetRequiredWeld() != null)
             {

--- a/src/PrizmMainProject/Forms/Joint/NewEdit/JointNewEditXtraForm.cs
+++ b/src/PrizmMainProject/Forms/Joint/NewEdit/JointNewEditXtraForm.cs
@@ -44,6 +44,11 @@ namespace Prizm.Main.Forms.Joint.NewEdit
         ICommandManager commandManager = new CommandManager();
         ISecurityContext ctx = Program.Kernel.Get<ISecurityContext>();
         public bool IsMatchedByGuid(Guid id) { return this.id == id; }
+        private List<string> localizedAllJointStatus = new List<string>();
+        private void UpdateTextEdit()
+        {
+            jointNewEditBindingSoure.CancelEdit();
+        }
 
         public JointNewEditXtraForm(Guid id)
         {
@@ -123,8 +128,11 @@ namespace Prizm.Main.Forms.Joint.NewEdit
                .Add("DataSource", jointNewEditBindingSoure, "JointTestResults");
             repairOperations.DataBindings
                .Add("DataSource", jointNewEditBindingSoure, "JointWeldResults");
-            jointStatus.DataBindings
-                .Add("EditValue", jointNewEditBindingSoure, "JointConstructionStatus");
+
+            Binding bind = new Binding("EditValue", jointNewEditBindingSoure, "JointConstructionStatus");
+            bind.FormattingEnabled = true;
+            bind.Format += (sender, e) => { e.Value = (string)localizedAllJointStatus[(int)e.Value]; };
+            jointStatus.DataBindings.Add(bind);
 
 
 
@@ -190,6 +198,10 @@ namespace Prizm.Main.Forms.Joint.NewEdit
 
         private void JointNewEditXtraForm_Load(object sender, EventArgs e)
         {
+            foreach (var item in EnumWrapper<JointStatus>.EnumerateItems())
+            {
+                localizedAllJointStatus.Add(item.Item2);
+            }
             BindCommands();
             BindToViewModel();
             viewModel.PropertyChanged += (s, eve) => IsModified = true;
@@ -242,8 +254,13 @@ namespace Prizm.Main.Forms.Joint.NewEdit
                 new LocalizedItem(resultGridColumn, StringResources.JointNew_ResultGridColumn.Id),
                 new LocalizedItem(controlDateGridColumn, StringResources.JointNew_ControlDateGridColumn.Id),
                 new LocalizedItem(inspectorsGridColumn, StringResources.JointNew_InspectorsGridColumn.Id),
-                new LocalizedItem(valueGridColumn, StringResources.JointNew_ValueGridColumn.Id)
+                new LocalizedItem(valueGridColumn, StringResources.JointNew_ValueGridColumn.Id),
 
+                new LocalizedItem(UpdateTextEdit, localizedAllJointStatus,
+                        new string [] { StringResources.JointNewEdit_JointStatus_Undefined.Id,
+                            StringResources.JointSearch_JointStatus_Welded.Id, 
+                            StringResources.JointSearch_JointStatus_Lowered.Id, 
+                            StringResources.JointSearch_JointStatus_Withdrawn.Id} )
             };
         }
 

--- a/src/PrizmMainProject/Forms/Reports/Construction/ConstructionReportsXtraForm.Designer.cs
+++ b/src/PrizmMainProject/Forms/Reports/Construction/ConstructionReportsXtraForm.Designer.cs
@@ -28,7 +28,6 @@
         /// </summary>
         private void InitializeComponent()
         {
-            this.components = new System.ComponentModel.Container();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(ConstructionReportsXtraForm));
             this.reportType = new DevExpress.XtraEditors.ComboBoxEdit();
             this.generalLayout = new DevExpress.XtraLayout.LayoutControl();
@@ -60,7 +59,7 @@
             this.tracingModeLayoutControl = new DevExpress.XtraLayout.LayoutControlItem();
             this.infoLabelLayout = new DevExpress.XtraLayout.LayoutControlItem();
             this.emptySpaceItem1 = new DevExpress.XtraLayout.EmptySpaceItem();
-            this.bindingSource = new System.Windows.Forms.BindingSource(this.components);
+            this.bindingSource = new System.Windows.Forms.BindingSource();
             ((System.ComponentModel.ISupportInitialize)(this.reportType.Properties)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.generalLayout)).BeginInit();
             this.generalLayout.SuspendLayout();
@@ -130,11 +129,9 @@
             // 
             this.infoLabel.Location = new System.Drawing.Point(606, 43);
             this.infoLabel.Name = "infoLabel";
-            this.infoLabel.Size = new System.Drawing.Size(367, 26);
+            this.infoLabel.Size = new System.Drawing.Size(455, 13);
             this.infoLabel.StyleController = this.generalLayout;
             this.infoLabel.TabIndex = 76;
-            this.infoLabel.Text = "Данный тип отчета содержит все сваренные элементы расположенные \r\nмежду заданными" +
-    " точками не зависимо от их связности.";
             // 
             // tracingModeRadioGroup
             // 
@@ -462,7 +459,7 @@
             this.infoLabelLayout.CustomizationFormText = "layoutControlItem1";
             this.infoLabelLayout.Location = new System.Drawing.Point(567, 0);
             this.infoLabelLayout.Name = "infoLabelLayout";
-            this.infoLabelLayout.Size = new System.Drawing.Size(489, 30);
+            this.infoLabelLayout.Size = new System.Drawing.Size(489, 17);
             this.infoLabelLayout.Spacing = new DevExpress.XtraLayout.Utils.Padding(15, 15, 0, 0);
             this.infoLabelLayout.Text = "infoLabelLayout";
             this.infoLabelLayout.TextSize = new System.Drawing.Size(0, 0);
@@ -472,9 +469,9 @@
             // 
             this.emptySpaceItem1.AllowHotTrack = false;
             this.emptySpaceItem1.CustomizationFormText = "emptySpaceItem1";
-            this.emptySpaceItem1.Location = new System.Drawing.Point(567, 30);
+            this.emptySpaceItem1.Location = new System.Drawing.Point(567, 17);
             this.emptySpaceItem1.Name = "emptySpaceItem1";
-            this.emptySpaceItem1.Size = new System.Drawing.Size(489, 14);
+            this.emptySpaceItem1.Size = new System.Drawing.Size(489, 27);
             this.emptySpaceItem1.Text = "emptySpaceItem1";
             this.emptySpaceItem1.TextSize = new System.Drawing.Size(0, 0);
             // 

--- a/src/PrizmMainProject/Forms/Reports/Construction/ConstructionReportsXtraForm.cs
+++ b/src/PrizmMainProject/Forms/Reports/Construction/ConstructionReportsXtraForm.cs
@@ -85,7 +85,10 @@ namespace Prizm.Main.Forms.Reports.Construction
                 new LocalizedItem(tracingModeRadioGroup, 
                     new string[]{ StringResources.ConstructionReport_RadioJoints.Id, StringResources.ConstructionReport_RadioKP.Id }),
 
-                // other
+                // comboboxes
+                new LocalizedItem(type, new  string [] {StringResources.PartTypePipe.Id, StringResources.PartTypeSpool.Id, StringResources.PartTypeComponent.Id} ),
+                new LocalizedItem(reportType, new string[] {StringResources.ConstractionReport_ReportTypeTracingReport.Id, StringResources.ConstractionReport_ReportTypeUsedProductReport.Id}),
+
             };
         }
 

--- a/src/PrizmMainProject/Forms/Reports/Construction/ConstructionReportsXtraForm.cs
+++ b/src/PrizmMainProject/Forms/Reports/Construction/ConstructionReportsXtraForm.cs
@@ -110,6 +110,8 @@ namespace Prizm.Main.Forms.Reports.Construction
 
         private void ConstructionReportsXtraForm_Load(object sender, EventArgs e)
         {
+            infoLabel.Text = Program.LanguageManager.GetString(StringResources.ConstractionReport_TracingReportInfoLabelText);
+
             viewModel = (ConstructionReportViewModel)Program.Kernel.GetService(typeof(ConstructionReportViewModel));
 
             foreach (var item in EnumWrapper<PartType>.EnumerateItems(skip0:true))

--- a/src/PrizmMainProject/Languages/StringResources.cs
+++ b/src/PrizmMainProject/Languages/StringResources.cs
@@ -46,6 +46,12 @@ namespace Prizm.Main.Languages
         public static StringResource JointSearch_JointStatus_Withdrawn = new StringResource {
             Id = "JointSearch_JointStatus_Withdrawn",
             Description = "Вырезан"
+        };
+
+        public static StringResource JointNewEdit_JointStatus_Undefined = new StringResource
+        {
+            Id = "JointNewEdit_JointStatus_Undefined",
+            Description = "Неопределен"
         };        
         //part types
 

--- a/src/PrizmMainProject/Languages/StringResources.cs
+++ b/src/PrizmMainProject/Languages/StringResources.cs
@@ -2508,6 +2508,12 @@ namespace Prizm.Main.Languages
             Description = "Тип отчета. По использованным изделиям"
         };
 
+        public static StringResource ConstractionReport_TracingReportInfoLabelText = new StringResource
+        {
+            Id = "ConstractionReport_TracingReportInfoLabelText",
+            Description = "Отчеты на строительстве.Текст информационного поля отчета по использованным изделиям"
+        };
+
         #endregion //--- PipeConstractionReport ---
 
         #region --- WeldDateReport ---

--- a/src/PrizmMainProject/Languages/StringResources.cs
+++ b/src/PrizmMainProject/Languages/StringResources.cs
@@ -2496,6 +2496,18 @@ namespace Prizm.Main.Languages
             Description = "Предварительный просмотр отчёта"
         };
 
+        public static StringResource ConstractionReport_ReportTypeTracingReport = new StringResource
+        {
+            Id = "ConstractionReport_ReportTypeTracingReport",
+            Description = "Тип отчета. По трассировке"
+        };
+
+        public static StringResource ConstractionReport_ReportTypeUsedProductReport = new StringResource
+        {
+            Id = "ConstractionReport_ReportTypeUsedProductReport",
+            Description = "Тип отчета. По использованным изделиям"
+        };
+
         #endregion //--- PipeConstractionReport ---
 
         #region --- WeldDateReport ---

--- a/src/PrizmMainProject/Languages/StringResources.cs
+++ b/src/PrizmMainProject/Languages/StringResources.cs
@@ -3384,13 +3384,13 @@ namespace Prizm.Main.Languages
 
         public static StringResource ReleaseNoteNewEdit_ShippedStatus = new StringResource
         {
-            Id = "ReleaseNoteNewEdit_Shipped",
+            Id = "ReleaseNoteNewEdit_ShippedStatus",
             Description = "Статус разрешения на отгрузку: отгружено"
         };
 
         public static StringResource ReleaseNoteNewEdit_PendingStatus = new StringResource
         {
-            Id = "ReleaseNoteNewEdit_Pending",
+            Id = "ReleaseNoteNewEdit_PendingStatus",
             Description = "Статус разрешения на отгрузку: сформировано"
         };
 

--- a/src/PrizmMainProject/Properties/Resources.Designer.cs
+++ b/src/PrizmMainProject/Properties/Resources.Designer.cs
@@ -1606,6 +1606,42 @@ namespace Prizm.Main.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Комплектующее.
+        /// </summary>
+        internal static string PartTypeComponent {
+            get {
+                return ResourceManager.GetString("PartTypeComponent", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Труба.
+        /// </summary>
+        internal static string PartTypePipe {
+            get {
+                return ResourceManager.GetString("PartTypePipe", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Катушка.
+        /// </summary>
+        internal static string PartTypeSpool {
+            get {
+                return ResourceManager.GetString("PartTypeSpool", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Неопределен.
+        /// </summary>
+        internal static string PartTypeUndefined {
+            get {
+                return ResourceManager.GetString("PartTypeUndefined", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Текущий пароль введен неверно..
         /// </summary>
         internal static string PassChange_InvalidOldPassword {

--- a/src/PrizmMainProject/Properties/Resources.Designer.cs
+++ b/src/PrizmMainProject/Properties/Resources.Designer.cs
@@ -253,6 +253,24 @@ namespace Prizm.Main.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to По трассировке.
+        /// </summary>
+        internal static string ConstractionReport_ReportTypeTracingReport {
+            get {
+                return ResourceManager.GetString("ConstractionReport_ReportTypeTracingReport", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to По использованным изделиям.
+        /// </summary>
+        internal static string ConstractionReport_ReportTypeUsedProductReport {
+            get {
+                return ResourceManager.GetString("ConstractionReport_ReportTypeUsedProductReport", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Статус на строительстве.
         /// </summary>
         internal static string ConstructionStatus {

--- a/src/PrizmMainProject/Properties/Resources.Designer.cs
+++ b/src/PrizmMainProject/Properties/Resources.Designer.cs
@@ -271,6 +271,16 @@ namespace Prizm.Main.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Данный тип отчета содержит все сваренные элементы расположенные 
+        ///между заданными точками не зависимо от их связности..
+        /// </summary>
+        internal static string ConstractionReport_TracingReportInfoLabelText {
+            get {
+                return ResourceManager.GetString("ConstractionReport_TracingReportInfoLabelText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Статус на строительстве.
         /// </summary>
         internal static string ConstructionStatus {

--- a/src/PrizmMainProject/Properties/Resources.resx
+++ b/src/PrizmMainProject/Properties/Resources.resx
@@ -1002,6 +1002,10 @@
   <data name="ConstractionReport_ReportTypeUsedProductReport" xml:space="preserve">
     <value>По использованным изделиям</value>
   </data>
+  <data name="ConstractionReport_TracingReportInfoLabelText" xml:space="preserve">
+    <value>Данный тип отчета содержит все сваренные элементы расположенные 
+между заданными точками не зависимо от их связности.</value>
+  </data>
   <data name="PartTypeComponent" xml:space="preserve">
     <value>Комплектующее</value>
   </data>

--- a/src/PrizmMainProject/Properties/Resources.resx
+++ b/src/PrizmMainProject/Properties/Resources.resx
@@ -996,6 +996,12 @@
   <data name="Notification_WelderCertificateExpired_Critical" xml:space="preserve">
     <value>Сообщение об окончании срока: Сертификат просрочен</value>
   </data>
+  <data name="ConstractionReport_ReportTypeTracingReport" xml:space="preserve">
+    <value>По трассировке</value>
+  </data>
+  <data name="ConstractionReport_ReportTypeUsedProductReport" xml:space="preserve">
+    <value>По использованным изделиям</value>
+  </data>
   <data name="PartTypeComponent" xml:space="preserve">
     <value>Комплектующее</value>
   </data>

--- a/src/PrizmMainProject/Properties/Resources.resx
+++ b/src/PrizmMainProject/Properties/Resources.resx
@@ -996,4 +996,16 @@
   <data name="Notification_WelderCertificateExpired_Critical" xml:space="preserve">
     <value>Сообщение об окончании срока: Сертификат просрочен</value>
   </data>
+  <data name="PartTypeComponent" xml:space="preserve">
+    <value>Комплектующее</value>
+  </data>
+  <data name="PartTypePipe" xml:space="preserve">
+    <value>Труба</value>
+  </data>
+  <data name="PartTypeSpool" xml:space="preserve">
+    <value>Катушка</value>
+  </data>
+  <data name="PartTypeUndefined" xml:space="preserve">
+    <value>Неопределен</value>
+  </data>
 </root>


### PR DESCRIPTION
Added localization for part types, RN status, construction report types and hardcoded labels
Issue: Not all field names are localized #1163
Items:
label in tracing report (hardcoded)
type of report and type of Item in tracing report
pipeline elements search: type in checked combo is taken from Enum
incoming inspection, element type seems to be enum name 
joint status at new joint is taken from Enum
