### PR TITLE
Saving components with attached files in one transaction

### DIFF
--- a/install/Lang/Translations/Strings.en-EN.txt
+++ b/install/Lang/Translations/Strings.en-EN.txt
@@ -2009,3 +2009,9 @@ ConstractionReport_ReportTypeUsedProductReport=By used products
 
 ;Отчеты на строительстве.Текст информационного поля отчета по использованным изделиям
 ConstractionReport_TracingReportInfoLabelText = This report type contains all welded elements located between selected points regardless of their connectivity
+
+;Ошибка сохранения прикрепленных файлов
+ExternalFiles_NotCopied_Header=External files saving error
+
+;Прикрепленные файлы не сохранены
+ExternalFiles_NotCopied=Attached files weren't saved

--- a/src/PrizmMainProject/Forms/Component/ComponentRepositories.cs
+++ b/src/PrizmMainProject/Forms/Component/ComponentRepositories.cs
@@ -1,4 +1,6 @@
-﻿using Prizm.Data.DAL.Construction;
+﻿using Prizm.DAL.Hibernate;
+using Prizm.Data.DAL;
+using Prizm.Data.DAL.Construction;
 using Prizm.Data.DAL.Hibernate;
 using Prizm.Data.DAL.Mill;
 using NHibernate;
@@ -17,6 +19,7 @@ namespace Prizm.Main.Forms.Component
         private readonly IComponentRepository componentRepo;
         private readonly IComponentTypeRepository componentTypeRepo;
         private readonly IInspectorRepository repoInspector;
+        private readonly IFileRepository fileRepo;
 
         [Inject]
         public ComponentRepositories(ISession session)
@@ -25,6 +28,7 @@ namespace Prizm.Main.Forms.Component
             this.componentRepo = new ComponentRepository(session);
             this.componentTypeRepo = new ComponentTypeRepository(session);
             this.repoInspector = new InspectorRepository(session);
+            this.fileRepo = new FileRepository(session);
         }
 
         public IComponentRepository ComponentRepo
@@ -42,6 +46,11 @@ namespace Prizm.Main.Forms.Component
             get { return repoInspector; }
         }
 
+        public IFileRepository FileRepo
+        {
+            get { return fileRepo; }
+        }
+
         public void Commit()
         {
             session.Transaction.Commit();
@@ -50,6 +59,11 @@ namespace Prizm.Main.Forms.Component
         public void BeginTransaction()
         {
             session.BeginTransaction();
+        }
+
+        public void Rollback()
+        {
+            session.Transaction.Rollback();
         }
 
         public void Dispose()

--- a/src/PrizmMainProject/Forms/Component/IComponentRepositories.cs
+++ b/src/PrizmMainProject/Forms/Component/IComponentRepositories.cs
@@ -1,4 +1,5 @@
-﻿using Prizm.Data.DAL.Construction;
+﻿using Prizm.Data.DAL;
+using Prizm.Data.DAL.Construction;
 using Prizm.Data.DAL.Mill;
 using System;
 using System.Collections.Generic;
@@ -13,8 +14,10 @@ namespace Prizm.Main.Forms.Component
         IComponentRepository ComponentRepo { get; }
         IComponentTypeRepository ComponentTypeRepo { get; }
         IInspectorRepository RepoInspector { get; }
+        IFileRepository FileRepo { get; }
 
         void Commit();
         void BeginTransaction();
+        void Rollback();
     }
 }

--- a/src/PrizmMainProject/Forms/Component/NewEdit/SaveComponentCommand.cs
+++ b/src/PrizmMainProject/Forms/Component/NewEdit/SaveComponentCommand.cs
@@ -76,23 +76,51 @@ namespace Prizm.Main.Forms.Component.NewEdit
                     {
                         viewModel.Component.InspectionStatus = viewModel.Component.GetPartInspectionStatus();
                         repos.BeginTransaction();
+
+                    var filesViewModel = viewModel.FilesFormViewModel;
+                    viewModel.FilesFormViewModel.Item = viewModel.Component.Id;
+
+                    //saving attached documents
+                    bool fileCopySuccess = true;
+                    if ((null != filesViewModel) && (filesViewModel.FilesToAttach.Count != 0))
+                    {
+                        if (viewModel.FilesFormViewModel.TrySaveFiles())
+                        {
+                            viewModel.FilesFormViewModel.PersistFiles(repos);
+                        }
+                        else
+                        {
+                            fileCopySuccess = false;
+                            repos.Rollback();
+                        }
+                    }
+
+                    if (fileCopySuccess)
+                    {
                         repos.ComponentRepo.SaveOrUpdate(viewModel.Component);
                         repos.Commit();
                         repos.ComponentRepo.Evict(viewModel.Component);
                         viewModel.ModifiableView.IsModified = false;
                         viewModel.ModifiableView.UpdateState();
 
-                        //saving attached documents
-                        if (viewModel.FilesFormViewModel != null)
+                        if ((null != filesViewModel) && (filesViewModel.Files.Count > 0))
                         {
-                            viewModel.FilesFormViewModel.Item = viewModel.Component.Id;
-                            viewModel.FilesFormViewModel.AddExternalFileCommand.Execute();
+                            foreach (var file in viewModel.FilesFormViewModel.Files)
+                            {
+                                repos.FileRepo.Evict(file);
+                            }
                             viewModel.FilesFormViewModel = null;
                         }
 
                         notify.ShowSuccess(
-                             string.Concat(Program.LanguageManager.GetString(StringResources.ComponentNewEdit_Saved), viewModel.Number),
-                             Program.LanguageManager.GetString(StringResources.ComponentNewEdit_SavedHeader));
+                            string.Concat(Program.LanguageManager.GetString(StringResources.ComponentNewEdit_Saved), viewModel.Number),
+                            Program.LanguageManager.GetString(StringResources.ComponentNewEdit_SavedHeader));
+                    }
+                    else
+                    {
+                        notify.ShowError(Program.LanguageManager.GetString(StringResources.ExternalFiles_NotCopied),
+                            Program.LanguageManager.GetString(StringResources.ExternalFiles_NotCopied_Header));
+                    }
 
                         log.Info(string.Format("The entity #{0}, id:{1} has been saved in DB.",
                             viewModel.Component.Number,

--- a/src/PrizmMainProject/Forms/ExternalFile/ExternalFilesViewModel.cs
+++ b/src/PrizmMainProject/Forms/ExternalFile/ExternalFilesViewModel.cs
@@ -9,11 +9,13 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using System.IO;
+using Prizm.Main.Forms.Component;
 using Prizm.Main.Forms.ExternalFile;
 using Prizm.Main.Commands;
 using DevExpress.Mvvm.POCO;
 using Prizm.Main.Forms;
 using Prizm.Main.Common;
+using Prizm.Main.Languages;
 
 namespace Prizm.Main.Forms.ExternalFile
 {
@@ -121,6 +123,70 @@ namespace Prizm.Main.Forms.ExternalFile
             {
                 Directory.Delete(Directories.TargetPathForView, true);
             }
+        }
+
+        public bool TrySaveFiles()
+        {
+            bool result = true;
+            if (FilesToAttach.Count > 0)
+            {
+                if (!Directory.Exists(Directories.TargetPath))
+                {
+                    Directory.CreateDirectory(Directories.TargetPath);
+                    DirectoryInfo directoryInfo = new DirectoryInfo(Directories.TargetPath);
+                    directoryInfo.Attributes |= FileAttributes.Hidden;
+                }
+                foreach (KeyValuePair<string, string> kvp in FilesToAttach)
+                {
+                    var newFileName = kvp.Key;
+                    try
+                    {
+                        System.IO.File.Copy(
+                        Directories.FilesToAttachFolder + newFileName,
+                        Directories.TargetPath + newFileName
+                        );
+                    }
+                    catch (Exception e)
+                    {
+                        result = false;
+                        RemoveCopiedFilesIfError();
+                        break;
+                    }
+                }
+            }
+            return result;
+        }
+        private void RemoveCopiedFilesIfError()
+        {
+            foreach (KeyValuePair<string, string> kvp in FilesToAttach)
+            {
+                if (System.IO.File.Exists(Directories.TargetPath + kvp.Key))
+                {
+                    System.IO.File.Delete(Directories.TargetPath + kvp.Key);
+                }
+                if (System.IO.File.Exists(Directories.FilesToAttachFolder + kvp.Key))
+                {
+                    System.IO.File.Delete(Directories.FilesToAttachFolder + kvp.Key);
+                }
+            }
+        }
+        public void PersistFiles(IComponentRepositories repos)
+        {
+            foreach (KeyValuePair<string, string> kvp in FilesToAttach)
+            {
+                Prizm.Domain.Entity.File fileEntity = new Domain.Entity.File()
+                {
+                    FileName = kvp.Value,
+                    UploadDate = DateTime.Now,
+                    Item = Item,
+                    IsActive = true,
+                    NewName = kvp.Key
+                };
+                repos.FileRepo.Save(fileEntity);
+            }
+
+            notify.ShowNotify(Program.LanguageManager.GetString(StringResources.ExternalFiles_FileAttachSuccess),
+                Program.LanguageManager.GetString(StringResources.ExternalFiles_FileAttachSuccessHeader));
         }
         
     }

--- a/src/PrizmMainProject/Forms/ExternalFile/ExternalFilesXtraForm.cs
+++ b/src/PrizmMainProject/Forms/ExternalFile/ExternalFilesXtraForm.cs
@@ -27,13 +27,9 @@ namespace Prizm.Main.Forms.ExternalFile
                 .Get<ExternalFilesViewModel>(
                 new ConstructorArgument("item", item));
 
-            if(isEditMode)
+            if (!isEditMode)
             {
-                buttonLayoutControlGroup.Visibility = DevExpress.XtraLayout.Utils.LayoutVisibility.Always;
-            }
-            else
-            {
-                buttonLayoutControlGroup.Visibility = DevExpress.XtraLayout.Utils.LayoutVisibility.Never;
+                buttonLayoutControlGroup.Enabled = false;
             }
         }
 

--- a/src/PrizmMainProject/Languages/StringResources.cs
+++ b/src/PrizmMainProject/Languages/StringResources.cs
@@ -277,6 +277,18 @@ namespace Prizm.Main.Languages
             Description = "Загрузка файла"
         };
 
+        public static StringResource ExternalFiles_NotCopied = new StringResource
+        {
+            Id = "ExternalFiles_NotCopied",
+            Description = "Прикрепленные файлы не сохранены"
+        };
+
+        public static StringResource ExternalFiles_NotCopied_Header = new StringResource
+        {
+            Id = "ExternalFiles_NotCopied_Header",
+            Description = "Ошибка сохранения прикрепленных файлов"
+        };
+
         public static StringResource ExternalFiles_FileDownloadSuccess = new StringResource
         {
             Id = "ExternalFiles_FileDownloadSuccess",


### PR DESCRIPTION
Saving files should be one transaction with saving the entity #854 

also fixes the problem "Make "edit attachments" availability by appropriate entity editing availability. #1129"
