### PR TITLE
Localization: pipe test result status, inspections fact bool hardcoded, settings error message, control types and test results

### DIFF
--- a/install/Lang/Translations/Strings.en-EN.txt
+++ b/install/Lang/Translations/Strings.en-EN.txt
@@ -2027,3 +2027,33 @@ WorkstationType_Mill=Mill
 
 ;Тип рабочей станции. Строительство
 WorkstationType_Construction=Construction
+
+;Вид контроля. Освидетельствование
+ControlTypeWitness=Witness
+
+;Вид контроля. Проверка документов
+ControlTypeReview=Review
+
+;Вид контроля. Мониторинг
+ControlTypeMonitor=Monitor
+
+;Вид контроля. Обязательная проверка
+ControlTypeHold=Hold
+
+;Необходимо проверить значение
+Settings_CheckValues=Please, check values
+
+;Заголовок ошибки
+Settings_ErrorHeader=Error
+
+;Тип результата контрольной операции. Логический
+TestResultTypeBoolean=Boolean
+
+;Тип результата контрольной операции. Диапазон
+TestResultTypeRange=Range
+
+;Тип результата контрольной операции. Строка
+TestResultTypeString=String
+
+;Тип отчета.По трассировке
+ConstractionReport_ReportTypeTracingReport= Tracing report

--- a/install/Lang/Translations/Strings.en-EN.txt
+++ b/install/Lang/Translations/Strings.en-EN.txt
@@ -1992,26 +1992,14 @@ Notification_ExpiredCertificate_Warning=Certificate's date will be expired soon
 ;Результат контрольной операции. Ожидается
 PipeTestResultStatus_Scheduled=Scheduled
 
-;Тип рабочей станции. Неопределен
-WorkstationType_Undefined=Undefined
-
 ;Результат контрольной операции. Принят
 PipeTestResultStatus_Passed=Passed
-
-;Тип рабочей станции. Главный
-WorkstationType_Master=Master
 
 ;Результат контрольной операции. Брак
 PipeTestResultStatus_Failed=Failed
 
-;Тип рабочей станции. Завод
-WorkstationType_Mill=Mill
-
 ;Результат контрольной операции. Ремонт
 PipeTestResultStatus_Repair=Repair
-
-;Тип рабочей станции. Строительство
-WorkstationType_Construction=Construction
 
 ;Тип отчета. По трассировке
 ConstractionReport_ReportTypeTracingReport=Tracing report
@@ -2027,3 +2015,15 @@ ExternalFiles_NotCopied_Header=External files saving error
 
 ;Прикрепленные файлы не сохранены
 ExternalFiles_NotCopied=Attached files weren't saved
+
+;Тип рабочей станции. Неопределен
+WorkstationType_Undefined=Undefined
+
+;Тип рабочей станции. Главный
+WorkstationType_Master=Master
+
+;Тип рабочей станции. Завод
+WorkstationType_Mill=Mill
+
+;Тип рабочей станции. Строительство
+WorkstationType_Construction=Construction

--- a/install/Lang/Translations/Strings.en-EN.txt
+++ b/install/Lang/Translations/Strings.en-EN.txt
@@ -1977,3 +1977,15 @@ Notification_ExpiredCertificate_Critical=Certificate's date is expired
 
 ;Сообщение о приближении окончания срока: Заканчивается срок сертификата
 Notification_ExpiredCertificate_Warning=Certificate's date will be expired soon
+
+;Результат контрольной операции. Ожидается
+PipeTestResultStatus_Scheduled=Scheduled
+
+;Результат контрольной операции. Принят
+PipeTestResultStatus_Passed=Passed
+
+;Результат контрольной операции. Брак
+PipeTestResultStatus_Failed=Failed
+
+;Результат контрольной операции. Ремонт
+PipeTestResultStatus_Repair=Repair

--- a/src/PrizmMainProject/Forms/PipeMill/NewEdit/Inspections/InspectionAddEditViewModel.cs
+++ b/src/PrizmMainProject/Forms/PipeMill/NewEdit/Inspections/InspectionAddEditViewModel.cs
@@ -292,6 +292,19 @@ namespace Prizm.Main.Forms.PipeMill.NewEdit.Inspections
 
         #endregion
 
+        public int StatusIndex
+        {
+            get { return (int)Status - 1; }
+            set
+            {
+                if (value != (int)Status - 1)
+                {
+                    Status = (PipeTestResultStatus)value + 1;
+                    RaisePropertyChanged("StatusIndex");
+                }
+            }
+        }
+
         internal void ChangeTest(string code)
         {
             var test = availableTests.FirstOrDefault(x => x.Code == code);

--- a/src/PrizmMainProject/Forms/PipeMill/NewEdit/Inspections/InspectionAddEditViewModel.cs
+++ b/src/PrizmMainProject/Forms/PipeMill/NewEdit/Inspections/InspectionAddEditViewModel.cs
@@ -3,6 +3,7 @@ using Prizm.Domain.Entity;
 using Prizm.Domain.Entity.Mill;
 using Prizm.Domain.Entity.Setup;
 using Prizm.Main.Common;
+using Prizm.Main.Languages;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -147,7 +148,7 @@ namespace Prizm.Main.Forms.PipeMill.NewEdit.Inspections
                 switch(testResult.Operation.ResultType)
                 {
                     case PipeTestResultType.Boolean:
-                        expStr = (testResult.Operation.BoolExpected) ? "Да" : "Нет";
+                        expStr = (testResult.Operation.BoolExpected) ? Program.LanguageManager.GetString(StringResources.Yes) : Program.LanguageManager.GetString(StringResources.No);
                         break;
                     case PipeTestResultType.String:
                         expStr = testResult.Operation.StringExpected;

--- a/src/PrizmMainProject/Forms/PipeMill/NewEdit/Inspections/InspectionAddEditXtraForm.Designer.cs
+++ b/src/PrizmMainProject/Forms/PipeMill/NewEdit/Inspections/InspectionAddEditXtraForm.Designer.cs
@@ -28,14 +28,10 @@
         /// </summary>
         private void InitializeComponent()
         {
-            this.components = new System.ComponentModel.Container();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(InspectionAddEditXtraForm));
             this.rootLayoutControl = new DevExpress.XtraLayout.LayoutControl();
             this.factLimit = new DevExpress.XtraEditors.SpinEdit();
             this.factBool = new DevExpress.XtraEditors.CheckEdit();
-            this.status = new DevExpress.XtraEditors.GridLookUpEdit();
-            this.gridLookUpEdit1View = new DevExpress.XtraGrid.Views.Grid.GridView();
-            this.gridColumn1 = new DevExpress.XtraGrid.Columns.GridColumn();
             this.code = new DevExpress.XtraEditors.ComboBoxEdit();
             this.inspectors = new Prizm.Main.Controls.InspectorSelectionControl();
             this.date = new DevExpress.XtraEditors.DateEdit();
@@ -57,7 +53,6 @@
             this.expectedLayoutControlItem = new DevExpress.XtraLayout.LayoutControlItem();
             this.inspectorsLayoutControlItem = new DevExpress.XtraLayout.LayoutControlItem();
             this.bottomEmptySpaceItem = new DevExpress.XtraLayout.EmptySpaceItem();
-            this.statusLayoutControlItem = new DevExpress.XtraLayout.LayoutControlItem();
             this.factDiapasonLayoutControlGroup = new DevExpress.XtraLayout.LayoutControlGroup();
             this.factLimitLayout = new DevExpress.XtraLayout.LayoutControlItem();
             this.factBoolLayoutControlGroup = new DevExpress.XtraLayout.LayoutControlGroup();
@@ -66,15 +61,15 @@
             this.factStringLayoutControlItem = new DevExpress.XtraLayout.LayoutControlItem();
             this.dateLayoutControlItem = new DevExpress.XtraLayout.LayoutControlItem();
             this.footerEmptySpaceItem = new DevExpress.XtraLayout.EmptySpaceItem();
-            this.bindingSource = new System.Windows.Forms.BindingSource(this.components);
-            this.testsBindingSource = new System.Windows.Forms.BindingSource(this.components);
-            this.inspectorsBindingSource = new System.Windows.Forms.BindingSource(this.components);
+            this.bindingSource = new System.Windows.Forms.BindingSource();
+            this.testsBindingSource = new System.Windows.Forms.BindingSource();
+            this.inspectorsBindingSource = new System.Windows.Forms.BindingSource();
+            this.status = new DevExpress.XtraEditors.ComboBoxEdit();
+            this.statusLayoutControlItem = new DevExpress.XtraLayout.LayoutControlItem();
             ((System.ComponentModel.ISupportInitialize)(this.rootLayoutControl)).BeginInit();
             this.rootLayoutControl.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.factLimit.Properties)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.factBool.Properties)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.status.Properties)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.gridLookUpEdit1View)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.code.Properties)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.date.Properties.CalendarTimeProperties)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.date.Properties)).BeginInit();
@@ -94,7 +89,6 @@
             ((System.ComponentModel.ISupportInitialize)(this.expectedLayoutControlItem)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.inspectorsLayoutControlItem)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.bottomEmptySpaceItem)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.statusLayoutControlItem)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.factDiapasonLayoutControlGroup)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.factLimitLayout)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.factBoolLayoutControlGroup)).BeginInit();
@@ -106,13 +100,15 @@
             ((System.ComponentModel.ISupportInitialize)(this.bindingSource)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.testsBindingSource)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.inspectorsBindingSource)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.status.Properties)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.statusLayoutControlItem)).BeginInit();
             this.SuspendLayout();
             // 
             // rootLayoutControl
             // 
+            this.rootLayoutControl.Controls.Add(this.status);
             this.rootLayoutControl.Controls.Add(this.factLimit);
             this.rootLayoutControl.Controls.Add(this.factBool);
-            this.rootLayoutControl.Controls.Add(this.status);
             this.rootLayoutControl.Controls.Add(this.code);
             this.rootLayoutControl.Controls.Add(this.inspectors);
             this.rootLayoutControl.Controls.Add(this.date);
@@ -166,37 +162,6 @@
             this.factBool.StyleController = this.rootLayoutControl;
             this.factBool.TabIndex = 14;
             this.factBool.CheckedChanged += new System.EventHandler(this.factBool_CheckedChanged);
-            // 
-            // status
-            // 
-            this.status.EditValue = "";
-            this.status.Location = new System.Drawing.Point(32, 476);
-            this.status.Name = "status";
-            this.status.Properties.Buttons.AddRange(new DevExpress.XtraEditors.Controls.EditorButton[] {
-            new DevExpress.XtraEditors.Controls.EditorButton(DevExpress.XtraEditors.Controls.ButtonPredefines.Combo)});
-            this.status.Properties.DisplayMember = "Text";
-            this.status.Properties.ValueMember = "Value";
-            this.status.Properties.View = this.gridLookUpEdit1View;
-            this.status.Size = new System.Drawing.Size(325, 20);
-            this.status.StyleController = this.rootLayoutControl;
-            this.status.TabIndex = 13;
-            // 
-            // gridLookUpEdit1View
-            // 
-            this.gridLookUpEdit1View.Columns.AddRange(new DevExpress.XtraGrid.Columns.GridColumn[] {
-            this.gridColumn1});
-            this.gridLookUpEdit1View.FocusRectStyle = DevExpress.XtraGrid.Views.Grid.DrawFocusRectStyle.RowFocus;
-            this.gridLookUpEdit1View.Name = "gridLookUpEdit1View";
-            this.gridLookUpEdit1View.OptionsSelection.EnableAppearanceFocusedCell = false;
-            this.gridLookUpEdit1View.OptionsView.ShowGroupPanel = false;
-            // 
-            // gridColumn1
-            // 
-            this.gridColumn1.Caption = "Статус";
-            this.gridColumn1.FieldName = "Text";
-            this.gridColumn1.Name = "gridColumn1";
-            this.gridColumn1.Visible = true;
-            this.gridColumn1.VisibleIndex = 0;
             // 
             // code
             // 
@@ -400,11 +365,11 @@
             this.expectedLayoutControlItem,
             this.inspectorsLayoutControlItem,
             this.bottomEmptySpaceItem,
-            this.statusLayoutControlItem,
             this.factDiapasonLayoutControlGroup,
             this.factBoolLayoutControlGroup,
             this.factStringLayoutControlGroup,
-            this.dateLayoutControlItem});
+            this.dateLayoutControlItem,
+            this.statusLayoutControlItem});
             this.resultLayoutControlGroup.Location = new System.Drawing.Point(0, 99);
             this.resultLayoutControlGroup.Name = "resultLayoutControlGroup";
             this.resultLayoutControlGroup.Size = new System.Drawing.Size(796, 440);
@@ -439,23 +404,11 @@
             // 
             this.bottomEmptySpaceItem.AllowHotTrack = false;
             this.bottomEmptySpaceItem.CustomizationFormText = "emptySpaceItem3";
-            this.bottomEmptySpaceItem.Location = new System.Drawing.Point(0, 360);
+            this.bottomEmptySpaceItem.Location = new System.Drawing.Point(0, 350);
             this.bottomEmptySpaceItem.Name = "bottomEmptySpaceItem";
-            this.bottomEmptySpaceItem.Size = new System.Drawing.Size(339, 31);
+            this.bottomEmptySpaceItem.Size = new System.Drawing.Size(339, 41);
             this.bottomEmptySpaceItem.Text = "bottomEmptySpaceItem";
             this.bottomEmptySpaceItem.TextSize = new System.Drawing.Size(0, 0);
-            // 
-            // statusLayoutControlItem
-            // 
-            this.statusLayoutControlItem.Control = this.status;
-            this.statusLayoutControlItem.CustomizationFormText = "Статус";
-            this.statusLayoutControlItem.Location = new System.Drawing.Point(0, 310);
-            this.statusLayoutControlItem.Name = "statusLayoutControlItem";
-            this.statusLayoutControlItem.Size = new System.Drawing.Size(339, 50);
-            this.statusLayoutControlItem.Spacing = new DevExpress.XtraLayout.Utils.Padding(5, 5, 5, 5);
-            this.statusLayoutControlItem.Text = "Статус";
-            this.statusLayoutControlItem.TextLocation = DevExpress.Utils.Locations.Top;
-            this.statusLayoutControlItem.TextSize = new System.Drawing.Size(62, 13);
             // 
             // factDiapasonLayoutControlGroup
             // 
@@ -549,6 +502,27 @@
             this.footerEmptySpaceItem.Text = "footerEmptySpaceItem";
             this.footerEmptySpaceItem.TextSize = new System.Drawing.Size(0, 0);
             // 
+            // status
+            // 
+            this.status.Location = new System.Drawing.Point(27, 471);
+            this.status.Name = "status";
+            this.status.Properties.Buttons.AddRange(new DevExpress.XtraEditors.Controls.EditorButton[] {
+            new DevExpress.XtraEditors.Controls.EditorButton(DevExpress.XtraEditors.Controls.ButtonPredefines.Combo)});
+            this.status.Size = new System.Drawing.Size(335, 20);
+            this.status.StyleController = this.rootLayoutControl;
+            this.status.TabIndex = 16;
+            // 
+            // statusLayoutControlItem
+            // 
+            this.statusLayoutControlItem.Control = this.status;
+            this.statusLayoutControlItem.CustomizationFormText = "Статус";
+            this.statusLayoutControlItem.Location = new System.Drawing.Point(0, 310);
+            this.statusLayoutControlItem.Name = "statusLayoutControlItem";
+            this.statusLayoutControlItem.Size = new System.Drawing.Size(339, 40);
+            this.statusLayoutControlItem.Text = "Статус";
+            this.statusLayoutControlItem.TextLocation = DevExpress.Utils.Locations.Top;
+            this.statusLayoutControlItem.TextSize = new System.Drawing.Size(62, 13);
+            // 
             // InspectionAddEditXtraForm
             // 
             this.AcceptButton = this.saveButton;
@@ -564,8 +538,6 @@
             this.rootLayoutControl.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.factLimit.Properties)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.factBool.Properties)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.status.Properties)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.gridLookUpEdit1View)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.code.Properties)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.date.Properties.CalendarTimeProperties)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.date.Properties)).EndInit();
@@ -585,7 +557,6 @@
             ((System.ComponentModel.ISupportInitialize)(this.expectedLayoutControlItem)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.inspectorsLayoutControlItem)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.bottomEmptySpaceItem)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.statusLayoutControlItem)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.factDiapasonLayoutControlGroup)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.factLimitLayout)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.factBoolLayoutControlGroup)).EndInit();
@@ -597,6 +568,8 @@
             ((System.ComponentModel.ISupportInitialize)(this.bindingSource)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.testsBindingSource)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.inspectorsBindingSource)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.status.Properties)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.statusLayoutControlItem)).EndInit();
             this.ResumeLayout(false);
 
         }
@@ -631,10 +604,6 @@
         private System.Windows.Forms.BindingSource inspectorsBindingSource;
         private DevExpress.XtraEditors.ComboBoxEdit code;
         private DevExpress.XtraLayout.LayoutControlItem codeLayoutControlItem;
-        private DevExpress.XtraEditors.GridLookUpEdit status;
-        private DevExpress.XtraGrid.Views.Grid.GridView gridLookUpEdit1View;
-        private DevExpress.XtraLayout.LayoutControlItem statusLayoutControlItem;
-        private DevExpress.XtraGrid.Columns.GridColumn gridColumn1;
         private DevExpress.XtraEditors.SpinEdit factLimit;
         private DevExpress.XtraEditors.CheckEdit factBool;
         private DevExpress.XtraLayout.LayoutControlGroup factDiapasonLayoutControlGroup;
@@ -642,5 +611,7 @@
         private DevExpress.XtraLayout.LayoutControlGroup factBoolLayoutControlGroup;
         private DevExpress.XtraLayout.LayoutControlItem factBoolLayoutControlItem;
         private DevExpress.XtraLayout.LayoutControlGroup factStringLayoutControlGroup;
+        private DevExpress.XtraEditors.ComboBoxEdit status;
+        private DevExpress.XtraLayout.LayoutControlItem statusLayoutControlItem;
     }
 }

--- a/src/PrizmMainProject/Forms/PipeMill/NewEdit/Inspections/InspectionAddEditXtraForm.cs
+++ b/src/PrizmMainProject/Forms/PipeMill/NewEdit/Inspections/InspectionAddEditXtraForm.cs
@@ -178,11 +178,11 @@ namespace Prizm.Main.Forms.PipeMill.NewEdit
         {
             if(factBool.Checked)
             {
-                factBool.Text = " [ Да ] ";
+                factBool.Text = " [ " + Program.LanguageManager.GetString(StringResources.Yes) + "] ";
             }
             else
             {
-                factBool.Text = " [ Нет ] ";
+                factBool.Text = " [ " + Program.LanguageManager.GetString(StringResources.No)  + " ] ";
             }
         }
     }

--- a/src/PrizmMainProject/Forms/PipeMill/NewEdit/Inspections/InspectionAddEditXtraForm.cs
+++ b/src/PrizmMainProject/Forms/PipeMill/NewEdit/Inspections/InspectionAddEditXtraForm.cs
@@ -52,9 +52,11 @@ namespace Prizm.Main.Forms.PipeMill.NewEdit
 
         private void InspectionAddEditXtraForm_Load(object sender, EventArgs e)
         {
+            foreach (var item in EnumWrapper<PipeTestResultStatus>.EnumerateItems(skip0: true))
+            {
+                status.Properties.Items.Add(item.Item2);
+            }
             BindToViewModel();
-            status.Text = string.Empty;
-            status.EditValue = viewModel.Status;
 
             factBool_CheckedChanged(null, null);
         }
@@ -72,8 +74,7 @@ namespace Prizm.Main.Forms.PipeMill.NewEdit
             name.DataBindings.Add("EditValue", bindingSource, "Name");
             expected.DataBindings.Add("EditValue", bindingSource, "Expected");
 
-            status.Properties.DataSource = viewModel.statuses;
-            status.DataBindings.Add("EditValue", bindingSource, "Status");
+            status.DataBindings.Add("SelectedIndex", bindingSource, "StatusIndex");
             date.DataBindings.Add("EditValue", bindingSource, "Date");
 
             factBool.DataBindings.Add("Checked", bindingSource, "FactBool");
@@ -106,7 +107,12 @@ namespace Prizm.Main.Forms.PipeMill.NewEdit
                 new LocalizedItem(factDiapasonLayoutControlGroup, StringResources.InspectionAddEdit_FactLimitGroup.Id),
 
                 new LocalizedItem(saveButton, StringResources.InspectionAddEdit_SaveButton.Id),
-                new LocalizedItem(cancelButton, StringResources.InspectionAddEdit_CancelButton.Id)
+                new LocalizedItem(cancelButton, StringResources.InspectionAddEdit_CancelButton.Id),
+
+                new LocalizedItem(status, new string [] {StringResources.PipeTestResultStatus_Scheduled.Id, 
+                                                         StringResources.PipeTestResultStatus_Passed.Id,
+                                                         StringResources.PipeTestResultStatus_Failed.Id,
+                                                         StringResources.PipeTestResultStatus_Repair.Id})
             };
         }
 

--- a/src/PrizmMainProject/Languages/StringResources.cs
+++ b/src/PrizmMainProject/Languages/StringResources.cs
@@ -144,13 +144,13 @@ namespace Prizm.Main.Languages
         public static StringResource PartInspectionStatus_Hold = new StringResource
         {
             Id = "PartInspectionStatus_Hold",
-            Description = "Статус на входном контроле. Задержан"
+            Description = "Статус на входном контроле. Задержано"
         };
 
         public static StringResource PartInspectionStatus_Rejected = new StringResource
         {
             Id = "PartInspectionStatus_Rejected",
-            Description = "Статус на входном контроле. Отклонено"
+            Description = "Статус на входном контроле. Брак"
         };
 
         public static StringResource PartInspectionStatus_Accepted = new StringResource
@@ -159,7 +159,6 @@ namespace Prizm.Main.Languages
             Description = "Статус на входном контроле. Принято"
         };
         #endregion
-
 
         #region --- Workstation types ---
         public static StringResource WorkstationType_Undefined = new StringResource
@@ -185,6 +184,34 @@ namespace Prizm.Main.Languages
             Id = "WorkstationType_Construction",
             Description = "Тип рабочей станции. Строительство"
         };
+        #endregion
+
+        #region --- Pipe test result statuses ---
+        public static StringResource PipeTestResultStatus_Scheduled = new StringResource
+        {
+            Id = "PipeTestResultStatus_Scheduled",
+            Description = "Результат контрольной операции. Ожидается"
+        };
+
+        public static StringResource PipeTestResultStatus_Passed = new StringResource
+        {
+            Id = "PipeTestResultStatus_Passed",
+            Description = "Результат контрольной операции. Принят"
+        };
+
+        public static StringResource PipeTestResultStatus_Failed = new StringResource
+        {
+            Id = "PipeTestResultStatus_Failed",
+            Description = "Результат контрольной операции. Брак"
+        };
+
+        public static StringResource PipeTestResultStatus_Repair = new StringResource
+        {
+            Id = "PipeTestResultStatus_Repair",
+            Description = "Результат контрольной операции. Ремонт"
+        };
+
+
         #endregion
 
         //messages 

--- a/src/PrizmMainProject/Properties/Resources.Designer.cs
+++ b/src/PrizmMainProject/Properties/Resources.Designer.cs
@@ -1570,7 +1570,7 @@ namespace Prizm.Main.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Отклонено.
+        ///   Looks up a localized string similar to Брак.
         /// </summary>
         internal static string PartInspectionStatus_Rejected {
             get {

--- a/src/PrizmMainProject/Properties/Resources.Designer.cs
+++ b/src/PrizmMainProject/Properties/Resources.Designer.cs
@@ -1461,6 +1461,15 @@ namespace Prizm.Main.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Нет.
+        /// </summary>
+        internal static string No {
+            get {
+                return ResourceManager.GetString("No", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Дубликат номера труб.
         /// </summary>
         internal static string Notification_DublicatePipeNumber_Critical {
@@ -2793,6 +2802,15 @@ namespace Prizm.Main.Properties {
         internal static string WorkstationType_Undefined {
             get {
                 return ResourceManager.GetString("WorkstationType_Undefined", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Да.
+        /// </summary>
+        internal static string Yes {
+            get {
+                return ResourceManager.GetString("Yes", resourceCulture);
             }
         }
         

--- a/src/PrizmMainProject/Properties/Resources.Designer.cs
+++ b/src/PrizmMainProject/Properties/Resources.Designer.cs
@@ -271,6 +271,42 @@ namespace Prizm.Main.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Обязательная проверка.
+        /// </summary>
+        internal static string ControlTypeHold {
+            get {
+                return ResourceManager.GetString("ControlTypeHold", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Мониторинг.
+        /// </summary>
+        internal static string ControlTypeMonitor {
+            get {
+                return ResourceManager.GetString("ControlTypeMonitor", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Проверка документов.
+        /// </summary>
+        internal static string ControlTypeReview {
+            get {
+                return ResourceManager.GetString("ControlTypeReview", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Освидетельствование.
+        /// </summary>
+        internal static string ControlTypeWitness {
+            get {
+                return ResourceManager.GetString("ControlTypeWitness", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized resource of type System.Drawing.Bitmap.
         /// </summary>
         internal static System.Drawing.Bitmap critical_warning {
@@ -2648,6 +2684,33 @@ namespace Prizm.Main.Properties {
         internal static string Test {
             get {
                 return ResourceManager.GetString("Test", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Логический.
+        /// </summary>
+        internal static string TestResultTypeBoolean {
+            get {
+                return ResourceManager.GetString("TestResultTypeBoolean", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Диапазон.
+        /// </summary>
+        internal static string TestResultTypeRange {
+            get {
+                return ResourceManager.GetString("TestResultTypeRange", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Строка.
+        /// </summary>
+        internal static string TestResultTypeString {
+            get {
+                return ResourceManager.GetString("TestResultTypeString", resourceCulture);
             }
         }
         

--- a/src/PrizmMainProject/Properties/Resources.Designer.cs
+++ b/src/PrizmMainProject/Properties/Resources.Designer.cs
@@ -2404,6 +2404,24 @@ namespace Prizm.Main.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Проверьте значения.
+        /// </summary>
+        internal static string Settings_CheckValues {
+            get {
+                return ResourceManager.GetString("Settings_CheckValues", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Ошибка.
+        /// </summary>
+        internal static string Settings_ErrorHeader {
+            get {
+                return ResourceManager.GetString("Settings_ErrorHeader", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Сохранение настроек.
         /// </summary>
         internal static string Settings_SetupSavedHeader {

--- a/src/PrizmMainProject/Properties/Resources.resx
+++ b/src/PrizmMainProject/Properties/Resources.resx
@@ -1038,10 +1038,31 @@
   <data name="Yes" xml:space="preserve">
     <value>Да</value>
   </data>
+  <data name="ControlTypeHold" xml:space="preserve">
+    <value>Обязательная проверка</value>
+  </data>
+  <data name="ControlTypeMonitor" xml:space="preserve">
+    <value>Мониторинг</value>
+  </data>
+  <data name="ControlTypeReview" xml:space="preserve">
+    <value>Проверка документов</value>
+  </data>
+  <data name="ControlTypeWitness" xml:space="preserve">
+    <value>Освидетельствование</value>
+  </data>
   <data name="Settings_CheckValues" xml:space="preserve">
     <value>Проверьте значения</value>
   </data>
   <data name="Settings_ErrorHeader" xml:space="preserve">
     <value>Ошибка</value>
+  </data>
+  <data name="TestResultTypeBoolean" xml:space="preserve">
+    <value>Логический</value>
+  </data>
+  <data name="TestResultTypeRange" xml:space="preserve">
+    <value>Диапазон</value>
+  </data>
+  <data name="TestResultTypeString" xml:space="preserve">
+    <value>Строка</value>
   </data>
 </root>

--- a/src/PrizmMainProject/Properties/Resources.resx
+++ b/src/PrizmMainProject/Properties/Resources.resx
@@ -1032,4 +1032,10 @@
   <data name="PartInspection_InspectionsSaved" xml:space="preserve">
     <value>Результаты контрольных операций успешно сохранены. Номер элемента: </value>
   </data>
+  <data name="No" xml:space="preserve">
+    <value>Нет</value>
+  </data>
+  <data name="Yes" xml:space="preserve">
+    <value>Да</value>
+  </data>
 </root>

--- a/src/PrizmMainProject/Properties/Resources.resx
+++ b/src/PrizmMainProject/Properties/Resources.resx
@@ -503,7 +503,7 @@
     <value>Пикеты</value>
   </data>
   <data name="PartInspectionStatus_Rejected" xml:space="preserve">
-    <value>Отклонено</value>
+    <value>Брак</value>
   </data>
   <data name="Question" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\Resources\Question.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>

--- a/src/PrizmMainProject/Properties/Resources.resx
+++ b/src/PrizmMainProject/Properties/Resources.resx
@@ -1038,4 +1038,10 @@
   <data name="Yes" xml:space="preserve">
     <value>Да</value>
   </data>
+  <data name="Settings_CheckValues" xml:space="preserve">
+    <value>Проверьте значения</value>
+  </data>
+  <data name="Settings_ErrorHeader" xml:space="preserve">
+    <value>Ошибка</value>
+  </data>
 </root>


### PR DESCRIPTION
Added localization for  pipe test result status, inspections fact bool hardcoded, settings error message, control types and test results.
Issue: Not all field names are localized #1163
Items:
mill pipe, inspection operations, operation status seems to be enum name.
"no resource" at settings validation message (create new sizetype and do not enter it's parameter and try to save)
factBool at inspection edit form seems to work wrong in localized way
