### PR TITLE
Localization: grid columns and repository lookup items

### DIFF
--- a/install/Lang/Translations/Strings.en-EN.txt
+++ b/install/Lang/Translations/Strings.en-EN.txt
@@ -2059,10 +2059,10 @@ TestResultTypeString=String
 ConstractionReport_ReportTypeTracingReport= Tracing report
 
 ;Настройки - Трубопровод.Тип операции.Контрольная
-JointOperationType_Test=Control operation
+JointOperationType_Test=Inspection
 
 ;Настройки - Трубопровод.Тип операции.Ремонтная
-JointOperationType_Action= Repair operation
+JointOperationType_Action= Repair
 
 ;Настройки - Трубопровод.Тип операции.Сварка
 JointOperationType_Weld=Weld

--- a/install/Lang/Translations/Strings.en-EN.txt
+++ b/install/Lang/Translations/Strings.en-EN.txt
@@ -2057,3 +2057,15 @@ TestResultTypeString=String
 
 ;Тип отчета.По трассировке
 ConstractionReport_ReportTypeTracingReport= Tracing report
+
+;Настройки - Трубопровод.Тип операции.Контрольная
+JointOperationType_Test=Control operation
+
+;Настройки - Трубопровод.Тип операции.Ремонтная
+JointOperationType_Action= Repair operation
+
+;Настройки - Трубопровод.Тип операции.Сварка
+JointOperationType_Weld=Weld
+
+;Настройки - Трубопровод.Тип операции.Вырезка стыка
+JointOperationType_Withdraw=Withdraw

--- a/src/Domain/Entity/Construction/PartInspectionStatus.cs
+++ b/src/Domain/Entity/Construction/PartInspectionStatus.cs
@@ -8,11 +8,12 @@ namespace Prizm.Domain.Entity.Construction
 {
     public enum PartInspectionStatus
     {
+        Undefined = 0,
         Pending = 1,
         Hold = 2,
         Rejected = 3,
         Accepted = 4,
 
-        Undefined = 0
+        
     }
 }

--- a/src/Domain/Entity/Setup/JointOperationType.cs
+++ b/src/Domain/Entity/Setup/JointOperationType.cs
@@ -8,11 +8,12 @@ namespace Prizm.Domain.Entity.Setup
 {
     public enum JointOperationType
     {
+        Undefined = 0,
         Test = 1,
         Action = 2,
         Weld = 3,
         Withdraw = 4,
 
-        Undefined = 0
+        
     }
 }

--- a/src/PrizmMainProject/Forms/Component/NewEdit/ComponentNewEditXtraForm.Designer.cs
+++ b/src/PrizmMainProject/Forms/Component/NewEdit/ComponentNewEditXtraForm.Designer.cs
@@ -28,7 +28,6 @@
         /// </summary>
         private void InitializeComponent()
         {
-            this.components = new System.ComponentModel.Container();
             DevExpress.XtraEditors.DXErrorProvider.ConditionValidationRule conditionValidationRule2 = new DevExpress.XtraEditors.DXErrorProvider.ConditionValidationRule();
             DevExpress.XtraEditors.DXErrorProvider.ConditionValidationRule conditionValidationRule1 = new DevExpress.XtraEditors.DXErrorProvider.ConditionValidationRule();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(ComponentNewEditXtraForm));
@@ -69,9 +68,9 @@
             this.newSaveLayoutControl = new DevExpress.XtraLayout.LayoutControlItem();
             this.saveButtonLayoutControl = new DevExpress.XtraLayout.LayoutControlItem();
             this.layoutControlDeactivation = new DevExpress.XtraLayout.LayoutControlItem();
-            this.componentBindingSource = new System.Windows.Forms.BindingSource(this.components);
-            this.inspectorsDataSource = new System.Windows.Forms.BindingSource(this.components);
-            this.dxValidationProvider = new DevExpress.XtraEditors.DXErrorProvider.DXValidationProvider(this.components);
+            this.componentBindingSource = new System.Windows.Forms.BindingSource();
+            this.inspectorsDataSource = new System.Windows.Forms.BindingSource();
+            this.dxValidationProvider = new DevExpress.XtraEditors.DXErrorProvider.DXValidationProvider();
             ((System.ComponentModel.ISupportInitialize)(this.componentNumber.Properties)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.newEditPipeLayout)).BeginInit();
             this.newEditPipeLayout.SuspendLayout();
@@ -294,9 +293,6 @@
             this.repositoryInspectionStatus.AutoHeight = false;
             this.repositoryInspectionStatus.Buttons.AddRange(new DevExpress.XtraEditors.Controls.EditorButton[] {
             new DevExpress.XtraEditors.Controls.EditorButton(DevExpress.XtraEditors.Controls.ButtonPredefines.Combo)});
-            this.repositoryInspectionStatus.Columns.AddRange(new DevExpress.XtraEditors.Controls.LookUpColumnInfo[] {
-            new DevExpress.XtraEditors.Controls.LookUpColumnInfo("Value", "Value")});
-            this.repositoryInspectionStatus.DisplayMember = "Value";
             this.repositoryInspectionStatus.DropDownRows = 5;
             this.repositoryInspectionStatus.Name = "repositoryInspectionStatus";
             this.repositoryInspectionStatus.NullText = "";

--- a/src/PrizmMainProject/Forms/Component/NewEdit/ComponentNewEditXtraForm.cs
+++ b/src/PrizmMainProject/Forms/Component/NewEdit/ComponentNewEditXtraForm.cs
@@ -28,8 +28,7 @@ namespace Prizm.Main.Forms.Component.NewEdit
         private Guid id;
         private ComponentNewEditViewModel viewModel;
         private InspectorSelectionControl inspectorSelectionControl = new InspectorSelectionControl();
-        private Dictionary<PartInspectionStatus, string> inspectionStatusDict
-            = new Dictionary<PartInspectionStatus, string>();
+        private List<string> localizedAllInspectionStatus = new List<string>();
         private ICommandManager commandManager = new CommandManager();
         ISecurityContext ctx = Program.Kernel.Get<ISecurityContext>();
 
@@ -94,7 +93,16 @@ namespace Prizm.Main.Forms.Component.NewEdit
                 new LocalizedItem(reasonColumn, StringResources.ComponentNewEdit_ReasonColumn.Id),
 
                 new LocalizedItem(diameterGridColumn, StringResources.ComponentNewEdit_DiameterGridColumn.Id),
-                new LocalizedItem(wallThicknessGridColumn, StringResources.ComponentNewEdit_WallThicknessGridColumn.Id)
+                new LocalizedItem(wallThicknessGridColumn, StringResources.ComponentNewEdit_WallThicknessGridColumn.Id),
+
+                new LocalizedItem(repositoryInspectionStatus, localizedAllInspectionStatus,new string []
+                                                                                      {
+                                                                                        StringResources.PartInspectionStatus_Pending.Id,
+                                                                                        StringResources.PartInspectionStatus_Hold.Id,
+                                                                                        StringResources.PartInspectionStatus_Rejected.Id,
+                                                                                        StringResources.PartInspectionStatus_Accepted.Id
+                                                                                      })
+
             };
         }
 
@@ -115,6 +123,10 @@ namespace Prizm.Main.Forms.Component.NewEdit
 
         private void ComponentNewEditXtraForm_Load(object sender, EventArgs e)
         {
+            foreach (var item in EnumWrapper<PartInspectionStatus>.EnumerateItems(skip0: true))
+            {
+                localizedAllInspectionStatus.Add(item.Item2);
+            }
             BindCommands();
             BindToViewModel();
 
@@ -160,17 +172,6 @@ namespace Prizm.Main.Forms.Component.NewEdit
             componentLength.DataBindings
                 .Add("EditValue", componentBindingSource, "Length");
             #endregion
-
-            inspectionStatusDict.Clear();
-            inspectionStatusDict.Add(PartInspectionStatus.Accepted,
-                Program.LanguageManager.GetString(StringResources.PartInspectionStatus_Accepted));
-            inspectionStatusDict.Add(PartInspectionStatus.Hold,
-                Program.LanguageManager.GetString(StringResources.PartInspectionStatus_Hold));
-            inspectionStatusDict.Add(PartInspectionStatus.Rejected,
-                Program.LanguageManager.GetString(StringResources.PartInspectionStatus_Rejected));
-            inspectionStatusDict.Add(PartInspectionStatus.Pending,
-                Program.LanguageManager.GetString(StringResources.PartInspectionStatus_Pending));
-            repositoryInspectionStatus.DataSource = inspectionStatusDict;
 
             inspectorsDataSource.DataSource = viewModel.Inspectors;
             inspectorsDataSource.ListChanged += (s, eve) => IsModified = true;
@@ -228,21 +229,23 @@ namespace Prizm.Main.Forms.Component.NewEdit
 
         private void repositoryInspectionStatus_CustomDisplayText(object sender, DevExpress.XtraEditors.Controls.CustomDisplayTextEventArgs e)
         {
-            if (e.Value is PartInspectionStatus)
-            {
-                e.DisplayText = inspectionStatusDict[(PartInspectionStatus)e.Value];
-            }
+           if (e.Value != null)
+           {
+               PartInspectionStatus result;
+               if (Enum.TryParse<PartInspectionStatus>(e.Value.ToString(), out result))
+               {
+                   e.DisplayText = localizedAllInspectionStatus[(int)result - 1];
+               }
+           }
         }
 
         private void repositoryInspectionStatus_EditValueChanged(object sender, EventArgs e)
         {
             LookUpEdit lookup = sender as LookUpEdit;
 
-            if (!(lookup.EditValue is PartInspectionStatus))
+            if (lookup.ItemIndex != -1)
             {
-                KeyValuePair<PartInspectionStatus, string> val
-                    = (KeyValuePair<PartInspectionStatus, string>)lookup.EditValue;
-                lookup.EditValue = val.Key;
+                lookup.EditValue = (PartInspectionStatus)lookup.ItemIndex + 1;
             }
         }
 

--- a/src/PrizmMainProject/Forms/Joint/Search/JointSearchXtraForm.Designer.cs
+++ b/src/PrizmMainProject/Forms/Joint/Search/JointSearchXtraForm.Designer.cs
@@ -170,6 +170,7 @@
             this.resultView.OptionsView.ShowIndicator = false;
             this.resultView.RowCellStyle += new DevExpress.XtraGrid.Views.Grid.RowCellStyleEventHandler(this.resultView_RowCellStyle);
             this.resultView.CustomUnboundColumnData += new DevExpress.XtraGrid.Views.Base.CustomColumnDataEventHandler(this.resultView_CustomUnboundColumnData);
+            this.resultView.CustomColumnDisplayText += new DevExpress.XtraGrid.Views.Base.CustomColumnDisplayTextEventHandler(this.resultView_CustomColumnDisplayText);
             this.resultView.DoubleClick += new System.EventHandler(this.resultView_DoubleClick);
             // 
             // idCol

--- a/src/PrizmMainProject/Forms/Joint/Search/JointSearchXtraForm.cs
+++ b/src/PrizmMainProject/Forms/Joint/Search/JointSearchXtraForm.cs
@@ -24,6 +24,7 @@ namespace Prizm.Main.Forms.Joint.Search
     {
         private JointSearchViewModel viewModel;
         ICommandManager commandManager = new CommandManager();
+        private List<string> localizedJointStatuses = new List<string>();
 
         [Inject]
         public JointSearchXtraForm(JointSearchViewModel vm)
@@ -51,6 +52,7 @@ namespace Prizm.Main.Forms.Joint.Search
             foreach(var item in EnumWrapper<JointStatus>.EnumerateItems(skip0:true))
             {
                 controlState.Properties.Items.Add(item.Item1, item.Item2, CheckState.Checked, enabled: true);
+                localizedJointStatuses.Add(item.Item2);
             }
             activity.SelectedIndex = 0;
             viewModel.Activity = ActivityCriteria.StatusActive;
@@ -120,7 +122,12 @@ namespace Prizm.Main.Forms.Joint.Search
                 new LocalizedItem(loweringDateCol, StringResources.JointSearch_LoweringDateCol.Id),
                 new LocalizedItem(gpsLatCol, StringResources.JointSearch_GpsLatCol.Id),
                 new LocalizedItem(gpsLongCol, StringResources.JointSearch_GpsLongCol.Id),
-                new LocalizedItem(gpsHeightCol, StringResources.JointSearch_GpsHeightCol.Id)
+                new LocalizedItem(gpsHeightCol, StringResources.JointSearch_GpsHeightCol.Id),
+                
+                new LocalizedItem(resultView, localizedJointStatuses,  new string[]{ 
+                    StringResources.JointSearch_JointStatus_Welded.Id, 
+                    StringResources.JointSearch_JointStatus_Lowered.Id, 
+                    StringResources.JointSearch_JointStatus_Withdrawn.Id} )
             };
         }
 
@@ -171,6 +178,18 @@ namespace Prizm.Main.Forms.Joint.Search
                 if (!data.IsActive)
                 {
                     e.Appearance.ForeColor = Color.Gray;
+                }
+            }
+        }
+
+        private void resultView_CustomColumnDisplayText(object sender, DevExpress.XtraGrid.Views.Base.CustomColumnDisplayTextEventArgs e)
+        {
+            if (e.Column.Name == statusLocalizedCol.Name && e.Value != null)
+            {
+                JointStatus result;
+                if (Enum.TryParse<JointStatus>(e.Value.ToString(), out result))
+                {
+                    e.DisplayText = localizedJointStatuses[(int)result - 1]; //-1 because we skip 0
                 }
             }
         }

--- a/src/PrizmMainProject/Forms/Parts/Inspection/InspectionSelectPartDialog.Designer.cs
+++ b/src/PrizmMainProject/Forms/Parts/Inspection/InspectionSelectPartDialog.Designer.cs
@@ -108,6 +108,7 @@
             this.searchResultsView.OptionsNavigation.UseTabKey = false;
             this.searchResultsView.OptionsView.ShowGroupPanel = false;
             this.searchResultsView.OptionsView.ShowIndicator = false;
+            this.searchResultsView.CustomColumnDisplayText += new DevExpress.XtraGrid.Views.Base.CustomColumnDisplayTextEventHandler(this.searchResultsView_CustomColumnDisplayText);
             // 
             // numberCol
             // 

--- a/src/PrizmMainProject/Forms/Parts/Inspection/InspectionSelectPartDialog.cs
+++ b/src/PrizmMainProject/Forms/Parts/Inspection/InspectionSelectPartDialog.cs
@@ -12,6 +12,8 @@ using Prizm.Main.Forms.Parts.Search;
 using Prizm.Main.Forms.MainChildForm;
 using Prizm.Main.Languages;
 using Prizm.Main.Properties;
+using Prizm.Main.Common;
+using Prizm.Domain.Entity.Construction;
 
 namespace Prizm.Main.Forms.Parts.Inspection
 {
@@ -20,6 +22,7 @@ namespace Prizm.Main.Forms.Parts.Inspection
     {
         BindingList<Part> parts;
         PartInspectionViewModel viewModel;
+        private List<string> localizedPartTypes = new List<string>();
         public InspectionSelectPartDialog(BindingList<Part> parts, PartInspectionViewModel viewModel)
         {
             this.parts = parts;
@@ -32,6 +35,10 @@ namespace Prizm.Main.Forms.Parts.Inspection
 
         private void NumbersDialog_Load(object sender, EventArgs e)
         {
+            foreach (var item in EnumWrapper<PartType>.EnumerateItems(skip0: true))
+            {
+                localizedPartTypes.Add(item.Item2);
+            }
             searchResults.DataSource = parts;
         }
 
@@ -47,6 +54,8 @@ namespace Prizm.Main.Forms.Parts.Inspection
                 // grid column headers
                 new LocalizedItem(numberCol, StringResources.InspectionSelectPartDialog_NumberColumnHeader.Id),
                 new LocalizedItem(typeCol, StringResources.InspectionSelectPartDialog_TypeColumnHeader.Id),
+                //grid column with enum
+                new LocalizedItem(searchResultsView, localizedPartTypes, new  string [] {StringResources.PartTypePipe.Id, StringResources.PartTypeSpool.Id, StringResources.PartTypeComponent.Id})
             };
         }
 
@@ -59,6 +68,18 @@ namespace Prizm.Main.Forms.Parts.Inspection
                 viewModel.SelectedElement = selectedElement;
             }
             this.Close();
+        }
+
+        private void searchResultsView_CustomColumnDisplayText(object sender, DevExpress.XtraGrid.Views.Base.CustomColumnDisplayTextEventArgs e)
+        {
+            if (e.Column.Name == typeCol.Name && e.Value != null)
+            {
+                PartType result;
+                if (Enum.TryParse<PartType>(e.Value.ToString(), out result))
+                {
+                    e.DisplayText = localizedPartTypes[(int)result - 1]; //-1 because we skip 0
+                }
+            }
         }
 
     }

--- a/src/PrizmMainProject/Forms/Parts/Inspection/PartInspectionXtraForm.Designer.cs
+++ b/src/PrizmMainProject/Forms/Parts/Inspection/PartInspectionXtraForm.Designer.cs
@@ -28,6 +28,7 @@
         /// </summary>
         private void InitializeComponent()
         {
+            this.components = new System.ComponentModel.Container();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(PartInspectionXtraForm));
             this.inspectionLayoutControl = new DevExpress.XtraLayout.LayoutControl();
             this.saveAndClearButton = new DevExpress.XtraEditors.SimpleButton();
@@ -36,11 +37,10 @@
             this.inspectionsView = new DevExpress.XtraGrid.Views.Grid.GridView();
             this.colDate = new DevExpress.XtraGrid.Columns.GridColumn();
             this.colResult = new DevExpress.XtraGrid.Columns.GridColumn();
-            this.resultCombo = new DevExpress.XtraEditors.Repository.RepositoryItemComboBox();
+            this.resultStatusLookUpEdit = new DevExpress.XtraEditors.Repository.RepositoryItemLookUpEdit();
             this.colInspector = new DevExpress.XtraGrid.Columns.GridColumn();
             this.inspectorsPopupContainerEdit = new DevExpress.XtraEditors.Repository.RepositoryItemPopupContainerEdit();
             this.colReason = new DevExpress.XtraGrid.Columns.GridColumn();
-            this.resultStatusLookUpEdit = new DevExpress.XtraEditors.Repository.RepositoryItemLookUpEdit();
             this.elementType = new DevExpress.XtraEditors.TextEdit();
             this.elementNumber = new DevExpress.XtraEditors.TextEdit();
             this.searchButton = new DevExpress.XtraEditors.SimpleButton();
@@ -58,15 +58,14 @@
             this.saveButtonLayout = new DevExpress.XtraLayout.LayoutControlItem();
             this.saveAndClearLayout = new DevExpress.XtraLayout.LayoutControlItem();
             this.buttonsEmptySpaceItem = new DevExpress.XtraLayout.EmptySpaceItem();
-            this.bindingSource = new System.Windows.Forms.BindingSource();
-            this.inspectorsDataSource = new System.Windows.Forms.BindingSource();
+            this.bindingSource = new System.Windows.Forms.BindingSource(this.components);
+            this.inspectorsDataSource = new System.Windows.Forms.BindingSource(this.components);
             ((System.ComponentModel.ISupportInitialize)(this.inspectionLayoutControl)).BeginInit();
             this.inspectionLayoutControl.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.inspections)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.inspectionsView)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.resultCombo)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.inspectorsPopupContainerEdit)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.resultStatusLookUpEdit)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.inspectorsPopupContainerEdit)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.elementType.Properties)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.elementNumber.Properties)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.searchNumber.Properties)).BeginInit();
@@ -133,8 +132,7 @@
             this.inspections.Name = "inspections";
             this.inspections.RepositoryItems.AddRange(new DevExpress.XtraEditors.Repository.RepositoryItem[] {
             this.resultStatusLookUpEdit,
-            this.inspectorsPopupContainerEdit,
-            this.resultCombo});
+            this.inspectorsPopupContainerEdit});
             this.inspections.Size = new System.Drawing.Size(848, 256);
             this.inspections.TabIndex = 8;
             this.inspections.ViewCollection.AddRange(new DevExpress.XtraGrid.Views.Base.BaseView[] {
@@ -169,19 +167,25 @@
             // colResult
             // 
             this.colResult.Caption = "Результат";
-            this.colResult.ColumnEdit = this.resultCombo;
+            this.colResult.ColumnEdit = this.resultStatusLookUpEdit;
             this.colResult.FieldName = "Status";
             this.colResult.Name = "colResult";
             this.colResult.Visible = true;
             this.colResult.VisibleIndex = 1;
             this.colResult.Width = 148;
             // 
-            // resultCombo
+            // resultStatusLookUpEdit
             // 
-            this.resultCombo.AutoHeight = false;
-            this.resultCombo.Buttons.AddRange(new DevExpress.XtraEditors.Controls.EditorButton[] {
+            this.resultStatusLookUpEdit.AutoHeight = false;
+            this.resultStatusLookUpEdit.Buttons.AddRange(new DevExpress.XtraEditors.Controls.EditorButton[] {
             new DevExpress.XtraEditors.Controls.EditorButton(DevExpress.XtraEditors.Controls.ButtonPredefines.Combo)});
-            this.resultCombo.Name = "resultCombo";
+            this.resultStatusLookUpEdit.Columns.AddRange(new DevExpress.XtraEditors.Controls.LookUpColumnInfo[] {
+            new DevExpress.XtraEditors.Controls.LookUpColumnInfo("Value", "Статус")});
+            this.resultStatusLookUpEdit.DisplayMember = "Value";
+            this.resultStatusLookUpEdit.Name = "resultStatusLookUpEdit";
+            this.resultStatusLookUpEdit.NullText = "";
+            this.resultStatusLookUpEdit.EditValueChanged += new System.EventHandler(this.resultStatusLookUpEdit_EditValueChanged);
+            this.resultStatusLookUpEdit.CustomDisplayText += new DevExpress.XtraEditors.Controls.CustomDisplayTextEventHandler(this.resultStatusLookUpEdit_CustomDisplayText);
             // 
             // colInspector
             // 
@@ -212,19 +216,6 @@
             this.colReason.Visible = true;
             this.colReason.VisibleIndex = 3;
             this.colReason.Width = 175;
-            // 
-            // resultStatusLookUpEdit
-            // 
-            this.resultStatusLookUpEdit.AutoHeight = false;
-            this.resultStatusLookUpEdit.Buttons.AddRange(new DevExpress.XtraEditors.Controls.EditorButton[] {
-            new DevExpress.XtraEditors.Controls.EditorButton(DevExpress.XtraEditors.Controls.ButtonPredefines.Combo)});
-            this.resultStatusLookUpEdit.Columns.AddRange(new DevExpress.XtraEditors.Controls.LookUpColumnInfo[] {
-            new DevExpress.XtraEditors.Controls.LookUpColumnInfo("Value", "Статус")});
-            this.resultStatusLookUpEdit.DisplayMember = "Value";
-            this.resultStatusLookUpEdit.Name = "resultStatusLookUpEdit";
-            this.resultStatusLookUpEdit.NullText = "";
-            this.resultStatusLookUpEdit.EditValueChanged += new System.EventHandler(this.resultStatusLookUpEdit_EditValueChanged);
-            this.resultStatusLookUpEdit.CustomDisplayText += new DevExpress.XtraEditors.Controls.CustomDisplayTextEventHandler(this.resultStatusLookUpEdit_CustomDisplayText);
             // 
             // elementType
             // 
@@ -439,9 +430,8 @@
             this.inspectionLayoutControl.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.inspections)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.inspectionsView)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.resultCombo)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.inspectorsPopupContainerEdit)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.resultStatusLookUpEdit)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.inspectorsPopupContainerEdit)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.elementType.Properties)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.elementNumber.Properties)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.searchNumber.Properties)).EndInit();
@@ -496,6 +486,5 @@
         private DevExpress.XtraEditors.SimpleButton saveAndClearButton;
         private DevExpress.XtraLayout.LayoutControlItem saveAndClearLayout;
         private DevExpress.XtraLayout.EmptySpaceItem buttonsEmptySpaceItem;
-        private DevExpress.XtraEditors.Repository.RepositoryItemComboBox resultCombo;
     }
 }

--- a/src/PrizmMainProject/Forms/Parts/Inspection/PartInspectionXtraForm.Designer.cs
+++ b/src/PrizmMainProject/Forms/Parts/Inspection/PartInspectionXtraForm.Designer.cs
@@ -28,7 +28,6 @@
         /// </summary>
         private void InitializeComponent()
         {
-            this.components = new System.ComponentModel.Container();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(PartInspectionXtraForm));
             this.inspectionLayoutControl = new DevExpress.XtraLayout.LayoutControl();
             this.saveAndClearButton = new DevExpress.XtraEditors.SimpleButton();
@@ -58,8 +57,8 @@
             this.saveButtonLayout = new DevExpress.XtraLayout.LayoutControlItem();
             this.saveAndClearLayout = new DevExpress.XtraLayout.LayoutControlItem();
             this.buttonsEmptySpaceItem = new DevExpress.XtraLayout.EmptySpaceItem();
-            this.bindingSource = new System.Windows.Forms.BindingSource(this.components);
-            this.inspectorsDataSource = new System.Windows.Forms.BindingSource(this.components);
+            this.bindingSource = new System.Windows.Forms.BindingSource();
+            this.inspectorsDataSource = new System.Windows.Forms.BindingSource();
             ((System.ComponentModel.ISupportInitialize)(this.inspectionLayoutControl)).BeginInit();
             this.inspectionLayoutControl.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.inspections)).BeginInit();
@@ -179,9 +178,6 @@
             this.resultStatusLookUpEdit.AutoHeight = false;
             this.resultStatusLookUpEdit.Buttons.AddRange(new DevExpress.XtraEditors.Controls.EditorButton[] {
             new DevExpress.XtraEditors.Controls.EditorButton(DevExpress.XtraEditors.Controls.ButtonPredefines.Combo)});
-            this.resultStatusLookUpEdit.Columns.AddRange(new DevExpress.XtraEditors.Controls.LookUpColumnInfo[] {
-            new DevExpress.XtraEditors.Controls.LookUpColumnInfo("Value", "Статус")});
-            this.resultStatusLookUpEdit.DisplayMember = "Value";
             this.resultStatusLookUpEdit.Name = "resultStatusLookUpEdit";
             this.resultStatusLookUpEdit.NullText = "";
             this.resultStatusLookUpEdit.EditValueChanged += new System.EventHandler(this.resultStatusLookUpEdit_EditValueChanged);

--- a/src/PrizmMainProject/Forms/Parts/Inspection/PartInspectionXtraForm.Designer.cs
+++ b/src/PrizmMainProject/Forms/Parts/Inspection/PartInspectionXtraForm.Designer.cs
@@ -28,7 +28,6 @@
         /// </summary>
         private void InitializeComponent()
         {
-            this.components = new System.ComponentModel.Container();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(PartInspectionXtraForm));
             this.inspectionLayoutControl = new DevExpress.XtraLayout.LayoutControl();
             this.saveAndClearButton = new DevExpress.XtraEditors.SimpleButton();
@@ -37,10 +36,11 @@
             this.inspectionsView = new DevExpress.XtraGrid.Views.Grid.GridView();
             this.colDate = new DevExpress.XtraGrid.Columns.GridColumn();
             this.colResult = new DevExpress.XtraGrid.Columns.GridColumn();
-            this.resultStatusLookUpEdit = new DevExpress.XtraEditors.Repository.RepositoryItemLookUpEdit();
+            this.resultCombo = new DevExpress.XtraEditors.Repository.RepositoryItemComboBox();
             this.colInspector = new DevExpress.XtraGrid.Columns.GridColumn();
             this.inspectorsPopupContainerEdit = new DevExpress.XtraEditors.Repository.RepositoryItemPopupContainerEdit();
             this.colReason = new DevExpress.XtraGrid.Columns.GridColumn();
+            this.resultStatusLookUpEdit = new DevExpress.XtraEditors.Repository.RepositoryItemLookUpEdit();
             this.elementType = new DevExpress.XtraEditors.TextEdit();
             this.elementNumber = new DevExpress.XtraEditors.TextEdit();
             this.searchButton = new DevExpress.XtraEditors.SimpleButton();
@@ -58,14 +58,15 @@
             this.saveButtonLayout = new DevExpress.XtraLayout.LayoutControlItem();
             this.saveAndClearLayout = new DevExpress.XtraLayout.LayoutControlItem();
             this.buttonsEmptySpaceItem = new DevExpress.XtraLayout.EmptySpaceItem();
-            this.bindingSource = new System.Windows.Forms.BindingSource(this.components);
-            this.inspectorsDataSource = new System.Windows.Forms.BindingSource(this.components);
+            this.bindingSource = new System.Windows.Forms.BindingSource();
+            this.inspectorsDataSource = new System.Windows.Forms.BindingSource();
             ((System.ComponentModel.ISupportInitialize)(this.inspectionLayoutControl)).BeginInit();
             this.inspectionLayoutControl.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.inspections)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.inspectionsView)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.resultStatusLookUpEdit)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.resultCombo)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.inspectorsPopupContainerEdit)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.resultStatusLookUpEdit)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.elementType.Properties)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.elementNumber.Properties)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.searchNumber.Properties)).BeginInit();
@@ -132,7 +133,8 @@
             this.inspections.Name = "inspections";
             this.inspections.RepositoryItems.AddRange(new DevExpress.XtraEditors.Repository.RepositoryItem[] {
             this.resultStatusLookUpEdit,
-            this.inspectorsPopupContainerEdit});
+            this.inspectorsPopupContainerEdit,
+            this.resultCombo});
             this.inspections.Size = new System.Drawing.Size(848, 256);
             this.inspections.TabIndex = 8;
             this.inspections.ViewCollection.AddRange(new DevExpress.XtraGrid.Views.Base.BaseView[] {
@@ -167,25 +169,19 @@
             // colResult
             // 
             this.colResult.Caption = "Результат";
-            this.colResult.ColumnEdit = this.resultStatusLookUpEdit;
+            this.colResult.ColumnEdit = this.resultCombo;
             this.colResult.FieldName = "Status";
             this.colResult.Name = "colResult";
             this.colResult.Visible = true;
             this.colResult.VisibleIndex = 1;
             this.colResult.Width = 148;
             // 
-            // resultStatusLookUpEdit
+            // resultCombo
             // 
-            this.resultStatusLookUpEdit.AutoHeight = false;
-            this.resultStatusLookUpEdit.Buttons.AddRange(new DevExpress.XtraEditors.Controls.EditorButton[] {
+            this.resultCombo.AutoHeight = false;
+            this.resultCombo.Buttons.AddRange(new DevExpress.XtraEditors.Controls.EditorButton[] {
             new DevExpress.XtraEditors.Controls.EditorButton(DevExpress.XtraEditors.Controls.ButtonPredefines.Combo)});
-            this.resultStatusLookUpEdit.Columns.AddRange(new DevExpress.XtraEditors.Controls.LookUpColumnInfo[] {
-            new DevExpress.XtraEditors.Controls.LookUpColumnInfo("Value", "Статус")});
-            this.resultStatusLookUpEdit.DisplayMember = "Value";
-            this.resultStatusLookUpEdit.Name = "resultStatusLookUpEdit";
-            this.resultStatusLookUpEdit.NullText = "";
-            this.resultStatusLookUpEdit.EditValueChanged += new System.EventHandler(this.resultStatusLookUpEdit_EditValueChanged);
-            this.resultStatusLookUpEdit.CustomDisplayText += new DevExpress.XtraEditors.Controls.CustomDisplayTextEventHandler(this.resultStatusLookUpEdit_CustomDisplayText);
+            this.resultCombo.Name = "resultCombo";
             // 
             // colInspector
             // 
@@ -216,6 +212,19 @@
             this.colReason.Visible = true;
             this.colReason.VisibleIndex = 3;
             this.colReason.Width = 175;
+            // 
+            // resultStatusLookUpEdit
+            // 
+            this.resultStatusLookUpEdit.AutoHeight = false;
+            this.resultStatusLookUpEdit.Buttons.AddRange(new DevExpress.XtraEditors.Controls.EditorButton[] {
+            new DevExpress.XtraEditors.Controls.EditorButton(DevExpress.XtraEditors.Controls.ButtonPredefines.Combo)});
+            this.resultStatusLookUpEdit.Columns.AddRange(new DevExpress.XtraEditors.Controls.LookUpColumnInfo[] {
+            new DevExpress.XtraEditors.Controls.LookUpColumnInfo("Value", "Статус")});
+            this.resultStatusLookUpEdit.DisplayMember = "Value";
+            this.resultStatusLookUpEdit.Name = "resultStatusLookUpEdit";
+            this.resultStatusLookUpEdit.NullText = "";
+            this.resultStatusLookUpEdit.EditValueChanged += new System.EventHandler(this.resultStatusLookUpEdit_EditValueChanged);
+            this.resultStatusLookUpEdit.CustomDisplayText += new DevExpress.XtraEditors.Controls.CustomDisplayTextEventHandler(this.resultStatusLookUpEdit_CustomDisplayText);
             // 
             // elementType
             // 
@@ -430,8 +439,9 @@
             this.inspectionLayoutControl.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.inspections)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.inspectionsView)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.resultStatusLookUpEdit)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.resultCombo)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.inspectorsPopupContainerEdit)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.resultStatusLookUpEdit)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.elementType.Properties)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.elementNumber.Properties)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.searchNumber.Properties)).EndInit();
@@ -486,5 +496,6 @@
         private DevExpress.XtraEditors.SimpleButton saveAndClearButton;
         private DevExpress.XtraLayout.LayoutControlItem saveAndClearLayout;
         private DevExpress.XtraLayout.EmptySpaceItem buttonsEmptySpaceItem;
+        private DevExpress.XtraEditors.Repository.RepositoryItemComboBox resultCombo;
     }
 }

--- a/src/PrizmMainProject/Forms/Parts/Inspection/PartInspectionXtraForm.cs
+++ b/src/PrizmMainProject/Forms/Parts/Inspection/PartInspectionXtraForm.cs
@@ -53,11 +53,6 @@ namespace Prizm.Main.Forms.Parts.Inspection
             {
                 localizedAllPartTypes.Add(item.Item2);
             }
-
-            foreach (var item in EnumWrapper<PartInspectionStatus>.EnumerateItems(skip0:true))
-            {
-                resultCombo.Items.Add(item.Item2);
-            }
             viewModel = (PartInspectionViewModel)Program.Kernel.GetService(typeof(PartInspectionViewModel));
             viewModel.CurrentForm = this;
             viewModel.ModifiableView = this;
@@ -99,6 +94,7 @@ namespace Prizm.Main.Forms.Parts.Inspection
             inspectionStatusDict.Add(PartInspectionStatus.Pending, Resources.PartInspectionStatus_Pending);
             inspectionStatusDict.Add(PartInspectionStatus.Undefined, string.Empty);
             resultStatusLookUpEdit.DataSource = inspectionStatusDict.Where(x => x.Key != PartInspectionStatus.Undefined);
+
             inspectorsDataSource.DataSource = viewModel.Inspectors;
             inspectorsDataSource.ListChanged += (s, eve) => IsModified = true;
             inspectorSelectionControl.DataSource = inspectorsDataSource;
@@ -140,10 +136,6 @@ namespace Prizm.Main.Forms.Parts.Inspection
                         new string [] {StringResources.PartTypeUndefined.Id, StringResources.PartTypePipe.Id, StringResources.PartTypeSpool.Id, StringResources.PartTypeComponent.Id} ),
 
                 //TODO: Create LocalizedItem for repository lookup item. When created, use StringResources.PartInspectionStatus_
-                new LocalizedItem(resultCombo,  new string [] {StringResources.PartInspectionStatus_Pending.Id, 
-                                                                  StringResources.PartInspectionStatus_Hold.Id,
-                                                                  StringResources.PartInspectionStatus_Accepted.Id,
-                                                                  StringResources.PartInspectionStatus_Rejected.Id})
 
             };
         }
@@ -258,6 +250,5 @@ namespace Prizm.Main.Forms.Parts.Inspection
                 e.Valid = false;
             }
         }
-
     }
 }

--- a/src/PrizmMainProject/Forms/Parts/Inspection/PartInspectionXtraForm.cs
+++ b/src/PrizmMainProject/Forms/Parts/Inspection/PartInspectionXtraForm.cs
@@ -27,10 +27,8 @@ namespace Prizm.Main.Forms.Parts.Inspection
         private PartInspectionViewModel viewModel;
         ICommandManager commandManager = new CommandManager();
         private InspectorSelectionControl inspectorSelectionControl = new InspectorSelectionControl();
-        private Dictionary<PartInspectionStatus, string> inspectionStatusDict
-            = new Dictionary<PartInspectionStatus, string>();
-        // do NOT re-create it because reference passed to localization item. Clean it instead.
         private List<string> localizedAllPartTypes = new List<string>();
+        private List<string> localizedAllInspectionStatus = new List<string>();
         private PartType originalPart = PartType.Undefined;
         private void UpdateTextEdit()
         {
@@ -52,6 +50,10 @@ namespace Prizm.Main.Forms.Parts.Inspection
             foreach (var item in EnumWrapper<PartType>.EnumerateItems())
             {
                 localizedAllPartTypes.Add(item.Item2);
+            }
+            foreach (var item in EnumWrapper<PartInspectionStatus>.EnumerateItems(skip0:true))
+            {
+                localizedAllInspectionStatus.Add(item.Item2);
             }
             viewModel = (PartInspectionViewModel)Program.Kernel.GetService(typeof(PartInspectionViewModel));
             viewModel.CurrentForm = this;
@@ -86,14 +88,6 @@ namespace Prizm.Main.Forms.Parts.Inspection
             elementType.DataBindings.Add(bind);
 
             inspections.DataBindings.Add("DataSource", bindingSource, "InspectionTestResults");
-
-            inspectionStatusDict.Clear();
-            inspectionStatusDict.Add(PartInspectionStatus.Accepted, Resources.PartInspectionStatus_Accepted);
-            inspectionStatusDict.Add(PartInspectionStatus.Hold, Resources.PartInspectionStatus_Hold);
-            inspectionStatusDict.Add(PartInspectionStatus.Rejected, Resources.PartInspectionStatus_Rejected);
-            inspectionStatusDict.Add(PartInspectionStatus.Pending, Resources.PartInspectionStatus_Pending);
-            inspectionStatusDict.Add(PartInspectionStatus.Undefined, string.Empty);
-            resultStatusLookUpEdit.DataSource = inspectionStatusDict.Where(x => x.Key != PartInspectionStatus.Undefined);
 
             inspectorsDataSource.DataSource = viewModel.Inspectors;
             inspectorsDataSource.ListChanged += (s, eve) => IsModified = true;
@@ -135,7 +129,13 @@ namespace Prizm.Main.Forms.Parts.Inspection
                     new LocalizedItem(UpdateTextEdit, localizedAllPartTypes,
                         new string [] {StringResources.PartTypeUndefined.Id, StringResources.PartTypePipe.Id, StringResources.PartTypeSpool.Id, StringResources.PartTypeComponent.Id} ),
 
-                //TODO: Create LocalizedItem for repository lookup item. When created, use StringResources.PartInspectionStatus_
+                new LocalizedItem(resultStatusLookUpEdit, localizedAllInspectionStatus,new string []
+                                                                                      {
+                                                                                        StringResources.PartInspectionStatus_Pending.Id,
+                                                                                        StringResources.PartInspectionStatus_Hold.Id,
+                                                                                        StringResources.PartInspectionStatus_Rejected.Id,
+                                                                                        StringResources.PartInspectionStatus_Accepted.Id
+                                                                                      })
 
             };
         }
@@ -144,21 +144,22 @@ namespace Prizm.Main.Forms.Parts.Inspection
 
         private void resultStatusLookUpEdit_CustomDisplayText(object sender, DevExpress.XtraEditors.Controls.CustomDisplayTextEventArgs e)
         {
-            if (e.Value is PartInspectionStatus)
+            if (e.Value != null)
             {
-                e.DisplayText = inspectionStatusDict[(PartInspectionStatus)e.Value];
+                PartInspectionStatus result;
+                if (Enum.TryParse<PartInspectionStatus>(e.Value.ToString(), out result))
+                {
+                    e.DisplayText = localizedAllInspectionStatus[(int)result-1];
+                }
             }
         }
 
         private void resultStatusLookUpEdit_EditValueChanged(object sender, EventArgs e)
-        {
+        {            
             LookUpEdit lookup = sender as LookUpEdit;
-
-            if (!(lookup.EditValue is PartInspectionStatus))
+            if (lookup.ItemIndex != -1)
             {
-                KeyValuePair<PartInspectionStatus, string> val
-                    = (KeyValuePair<PartInspectionStatus, string>)lookup.EditValue;
-                lookup.EditValue = val.Key;
+                lookup.EditValue = (PartInspectionStatus)lookup.ItemIndex + 1;
             }
         }
 
@@ -250,5 +251,6 @@ namespace Prizm.Main.Forms.Parts.Inspection
                 e.Valid = false;
             }
         }
+
     }
 }

--- a/src/PrizmMainProject/Forms/Parts/Inspection/PartInspectionXtraForm.cs
+++ b/src/PrizmMainProject/Forms/Parts/Inspection/PartInspectionXtraForm.cs
@@ -53,6 +53,11 @@ namespace Prizm.Main.Forms.Parts.Inspection
             {
                 localizedAllPartTypes.Add(item.Item2);
             }
+
+            foreach (var item in EnumWrapper<PartInspectionStatus>.EnumerateItems(skip0:true))
+            {
+                resultCombo.Items.Add(item.Item2);
+            }
             viewModel = (PartInspectionViewModel)Program.Kernel.GetService(typeof(PartInspectionViewModel));
             viewModel.CurrentForm = this;
             viewModel.ModifiableView = this;
@@ -94,7 +99,6 @@ namespace Prizm.Main.Forms.Parts.Inspection
             inspectionStatusDict.Add(PartInspectionStatus.Pending, Resources.PartInspectionStatus_Pending);
             inspectionStatusDict.Add(PartInspectionStatus.Undefined, string.Empty);
             resultStatusLookUpEdit.DataSource = inspectionStatusDict.Where(x => x.Key != PartInspectionStatus.Undefined);
-
             inspectorsDataSource.DataSource = viewModel.Inspectors;
             inspectorsDataSource.ListChanged += (s, eve) => IsModified = true;
             inspectorSelectionControl.DataSource = inspectorsDataSource;
@@ -136,6 +140,10 @@ namespace Prizm.Main.Forms.Parts.Inspection
                         new string [] {StringResources.PartTypeUndefined.Id, StringResources.PartTypePipe.Id, StringResources.PartTypeSpool.Id, StringResources.PartTypeComponent.Id} ),
 
                 //TODO: Create LocalizedItem for repository lookup item. When created, use StringResources.PartInspectionStatus_
+                new LocalizedItem(resultCombo,  new string [] {StringResources.PartInspectionStatus_Pending.Id, 
+                                                                  StringResources.PartInspectionStatus_Hold.Id,
+                                                                  StringResources.PartInspectionStatus_Accepted.Id,
+                                                                  StringResources.PartInspectionStatus_Rejected.Id})
 
             };
         }
@@ -250,5 +258,6 @@ namespace Prizm.Main.Forms.Parts.Inspection
                 e.Valid = false;
             }
         }
+
     }
 }

--- a/src/PrizmMainProject/Forms/Parts/Search/PartSearchXtraForm.Designer.cs
+++ b/src/PrizmMainProject/Forms/Parts/Search/PartSearchXtraForm.Designer.cs
@@ -144,6 +144,7 @@
             this.partsView.OptionsView.ShowFilterPanelMode = DevExpress.XtraGrid.Views.Base.ShowFilterPanelMode.Never;
             this.partsView.OptionsView.ShowGroupPanel = false;
             this.partsView.RowCellStyle += new DevExpress.XtraGrid.Views.Grid.RowCellStyleEventHandler(this.partsView_RowCellStyle);
+            this.partsView.CustomColumnDisplayText += new DevExpress.XtraGrid.Views.Base.CustomColumnDisplayTextEventHandler(this.partsView_CustomColumnDisplayText);
             this.partsView.KeyDown += new System.Windows.Forms.KeyEventHandler(this.partsView_KeyDown);
             this.partsView.DoubleClick += new System.EventHandler(this.partsView_DoubleClick);
             // 

--- a/src/PrizmMainProject/Forms/Parts/Search/PartSearchXtraForm.cs
+++ b/src/PrizmMainProject/Forms/Parts/Search/PartSearchXtraForm.cs
@@ -28,6 +28,7 @@ namespace Prizm.Main.Forms.Parts.Search
     {
         private PartSearchViewModel viewModel;
         ICommandManager commandManager = new CommandManager();
+        private List<string> localizedPartTypes = new List<string>();
 
         public PartSearchXtraForm()
         {
@@ -49,6 +50,7 @@ namespace Prizm.Main.Forms.Parts.Search
             foreach (var item in EnumWrapper<PartType>.EnumerateItems(skip0: true))
             {
                 type.Properties.Items.Add(item.Item1, item.Item2, CheckState.Checked, enabled:true);
+                localizedPartTypes.Add(item.Item2);
             }
             RefreshTypes();
             activity.SelectedIndex = 0;
@@ -90,6 +92,9 @@ namespace Prizm.Main.Forms.Parts.Search
                 // layout control groups
                 new LocalizedItem(searchLayoutControlGroup, StringResources.PartSearch_SearchGroup.Id),
                 new LocalizedItem(searchResultLayoutGroup, StringResources.PartSearch_SearchResultGroup.Id),
+
+                //grid column with enum
+                new LocalizedItem(partsView, localizedPartTypes, new  string [] {StringResources.PartTypePipe.Id, StringResources.PartTypeSpool.Id, StringResources.PartTypeComponent.Id})
                 // form
                 //??
             };
@@ -172,6 +177,18 @@ namespace Prizm.Main.Forms.Parts.Search
                 if (!data.IsActive)
                 {
                     e.Appearance.ForeColor = Color.Gray;
+                }
+            }
+        }
+
+        private void partsView_CustomColumnDisplayText(object sender, DevExpress.XtraGrid.Views.Base.CustomColumnDisplayTextEventArgs e)
+        {
+            if (e.Column.Name == typeCol.Name && e.Value != null)
+            {
+                PartType result;
+                if (Enum.TryParse<PartType>(e.Value.ToString(), out result))
+                {
+                    e.DisplayText = localizedPartTypes[(int)result - 1]; //-1 because we skip 0
                 }
             }
         }

--- a/src/PrizmMainProject/Forms/PipeMill/NewEdit/MillPipeNewEditXtraForm.Designer.cs
+++ b/src/PrizmMainProject/Forms/PipeMill/NewEdit/MillPipeNewEditXtraForm.Designer.cs
@@ -28,19 +28,18 @@
         /// </summary>
         private void InitializeComponent()
         {
-            this.components = new System.ComponentModel.Container();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(MillPipeNewEditXtraForm));
             DevExpress.Utils.Animation.FadeTransition fadeTransition1 = new DevExpress.Utils.Animation.FadeTransition();
             this.weldersListGridView = new DevExpress.XtraGrid.Views.Grid.GridView();
             this.firstNameGridColumn = new DevExpress.XtraGrid.Columns.GridColumn();
             this.lastNameGridColumn = new DevExpress.XtraGrid.Columns.GridColumn();
             this.weldingHistory = new DevExpress.XtraGrid.GridControl();
-            this.weldBindingSource = new System.Windows.Forms.BindingSource(this.components);
+            this.weldBindingSource = new System.Windows.Forms.BindingSource();
             this.weldingHistoryGridView = new DevExpress.XtraGrid.Views.Grid.GridView();
             this.weldingDateGridColumn = new DevExpress.XtraGrid.Columns.GridColumn();
             this.weldersGridColumn = new DevExpress.XtraGrid.Columns.GridColumn();
             this.repositoryItemPopupWelders = new DevExpress.XtraEditors.Repository.RepositoryItemPopupContainerEdit();
-            this.weldersDataSource = new System.Windows.Forms.BindingSource(this.components);
+            this.weldersDataSource = new System.Windows.Forms.BindingSource();
             this.steelGrade = new DevExpress.XtraEditors.TextEdit();
             this.generalPipeLayout = new DevExpress.XtraLayout.LayoutControl();
             this.labelControl1 = new DevExpress.XtraEditors.LabelControl();
@@ -48,13 +47,12 @@
             this.addInspectionButton = new DevExpress.XtraEditors.SimpleButton();
             this.pipeLength = new DevExpress.XtraEditors.TextEdit();
             this.inspections = new DevExpress.XtraGrid.GridControl();
-            this.inspectionOperation = new System.Windows.Forms.BindingSource(this.components);
+            this.inspectionOperation = new System.Windows.Forms.BindingSource();
             this.inspectionsGridView = new DevExpress.XtraGrid.Views.Grid.GridView();
             this.inspectionNameGridColumn = new DevExpress.XtraGrid.Columns.GridColumn();
             this.valueGridColumn = new DevExpress.XtraGrid.Columns.GridColumn();
             this.testResultValue = new DevExpress.XtraEditors.Repository.RepositoryItemTextEdit();
             this.inspectionResultGridColumn = new DevExpress.XtraGrid.Columns.GridColumn();
-            this.resultStatusLookUpEdit = new DevExpress.XtraEditors.Repository.RepositoryItemLookUpEdit();
             this.inspectorsGridColumn = new DevExpress.XtraGrid.Columns.GridColumn();
             this.inspectorsPopupContainerEdit = new DevExpress.XtraEditors.Repository.RepositoryItemPopupContainerEdit();
             this.controlDateGridColumn = new DevExpress.XtraGrid.Columns.GridColumn();
@@ -62,6 +60,7 @@
             this.inspectionCodeLookUpEdit = new DevExpress.XtraEditors.Repository.RepositoryItemLookUpEdit();
             this.categoryGridColumn = new DevExpress.XtraGrid.Columns.GridColumn();
             this.expectedResultGridColumn = new DevExpress.XtraGrid.Columns.GridColumn();
+            this.resultStatusLookUpEdit = new DevExpress.XtraEditors.Repository.RepositoryItemLookUpEdit();
             this.plateThickness = new DevExpress.XtraEditors.TextEdit();
             this.plateNumber = new DevExpress.XtraEditors.TextEdit();
             this.shippedDate = new DevExpress.XtraEditors.TextEdit();
@@ -78,7 +77,7 @@
             this.railcarNumber = new DevExpress.XtraEditors.TextEdit();
             this.saveAndNewButton = new DevExpress.XtraEditors.SimpleButton();
             this.coatingHistory = new DevExpress.XtraGrid.GridControl();
-            this.coatDataSource = new System.Windows.Forms.BindingSource(this.components);
+            this.coatDataSource = new System.Windows.Forms.BindingSource();
             this.coatingHistoryGridView = new DevExpress.XtraGrid.Views.Grid.GridView();
             this.coatingDateGridColumn = new DevExpress.XtraGrid.Columns.GridColumn();
             this.coatingTypeGridColumn = new DevExpress.XtraGrid.Columns.GridColumn();
@@ -140,10 +139,10 @@
             this.layoutControlItem1 = new DevExpress.XtraLayout.LayoutControlItem();
             this.plateNumberLayout = new DevExpress.XtraLayout.LayoutControlItem();
             this.certificateEmptySpace = new DevExpress.XtraLayout.EmptySpaceItem();
-            this.weldingDs = new System.Windows.Forms.BindingSource(this.components);
-            this.pipeNewEditBindingSource = new System.Windows.Forms.BindingSource(this.components);
-            this.inspectorsDataSource = new System.Windows.Forms.BindingSource(this.components);
-            this.dxValidationProvider = new DevExpress.XtraEditors.DXErrorProvider.DXValidationProvider(this.components);
+            this.weldingDs = new System.Windows.Forms.BindingSource();
+            this.pipeNewEditBindingSource = new System.Windows.Forms.BindingSource();
+            this.inspectorsDataSource = new System.Windows.Forms.BindingSource();
+            this.dxValidationProvider = new DevExpress.XtraEditors.DXErrorProvider.DXValidationProvider();
             this.workspaceManager = new DevExpress.Utils.WorkspaceManager();
             this.openFileDialog = new System.Windows.Forms.OpenFileDialog();
             ((System.ComponentModel.ISupportInitialize)(this.weldersListGridView)).BeginInit();
@@ -160,9 +159,9 @@
             ((System.ComponentModel.ISupportInitialize)(this.inspectionOperation)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.inspectionsGridView)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.testResultValue)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.resultStatusLookUpEdit)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.inspectorsPopupContainerEdit)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.inspectionCodeLookUpEdit)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.resultStatusLookUpEdit)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.plateThickness.Properties)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.plateNumber.Properties)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.shippedDate.Properties)).BeginInit();
@@ -463,6 +462,7 @@
             this.inspectionsGridView.InitNewRow += new DevExpress.XtraGrid.Views.Grid.InitNewRowEventHandler(this.inspectionsGridView_InitNewRow);
             this.inspectionsGridView.CellValueChanged += new DevExpress.XtraGrid.Views.Base.CellValueChangedEventHandler(this.CellModifiedGridView_CellValueChanged);
             this.inspectionsGridView.ValidateRow += new DevExpress.XtraGrid.Views.Base.ValidateRowEventHandler(this.inspectionsGridView_ValidateRow);
+            this.inspectionsGridView.CustomColumnDisplayText += new DevExpress.XtraGrid.Views.Base.CustomColumnDisplayTextEventHandler(this.inspectionsGridView_CustomColumnDisplayText);
             this.inspectionsGridView.DoubleClick += new System.EventHandler(this.inspectionsGridView_DoubleClick);
             // 
             // inspectionNameGridColumn
@@ -494,25 +494,12 @@
             // inspectionResultGridColumn
             // 
             this.inspectionResultGridColumn.Caption = "Результат контроля";
-            this.inspectionResultGridColumn.ColumnEdit = this.resultStatusLookUpEdit;
             this.inspectionResultGridColumn.FieldName = "Status";
             this.inspectionResultGridColumn.Name = "inspectionResultGridColumn";
             this.inspectionResultGridColumn.OptionsColumn.AllowEdit = false;
             this.inspectionResultGridColumn.Visible = true;
             this.inspectionResultGridColumn.VisibleIndex = 5;
             this.inspectionResultGridColumn.Width = 62;
-            // 
-            // resultStatusLookUpEdit
-            // 
-            this.resultStatusLookUpEdit.AutoHeight = false;
-            this.resultStatusLookUpEdit.Buttons.AddRange(new DevExpress.XtraEditors.Controls.EditorButton[] {
-            new DevExpress.XtraEditors.Controls.EditorButton(DevExpress.XtraEditors.Controls.ButtonPredefines.Combo)});
-            this.resultStatusLookUpEdit.Columns.AddRange(new DevExpress.XtraEditors.Controls.LookUpColumnInfo[] {
-            new DevExpress.XtraEditors.Controls.LookUpColumnInfo("Text", "Статус результата")});
-            this.resultStatusLookUpEdit.DisplayMember = "Text";
-            this.resultStatusLookUpEdit.Name = "resultStatusLookUpEdit";
-            this.resultStatusLookUpEdit.NullText = "";
-            this.resultStatusLookUpEdit.ValueMember = "Value";
             // 
             // inspectorsGridColumn
             // 
@@ -593,6 +580,18 @@
             this.expectedResultGridColumn.Visible = true;
             this.expectedResultGridColumn.VisibleIndex = 3;
             this.expectedResultGridColumn.Width = 68;
+            // 
+            // resultStatusLookUpEdit
+            // 
+            this.resultStatusLookUpEdit.AutoHeight = false;
+            this.resultStatusLookUpEdit.Buttons.AddRange(new DevExpress.XtraEditors.Controls.EditorButton[] {
+            new DevExpress.XtraEditors.Controls.EditorButton(DevExpress.XtraEditors.Controls.ButtonPredefines.Combo)});
+            this.resultStatusLookUpEdit.Columns.AddRange(new DevExpress.XtraEditors.Controls.LookUpColumnInfo[] {
+            new DevExpress.XtraEditors.Controls.LookUpColumnInfo("Text", "Статус результата")});
+            this.resultStatusLookUpEdit.DisplayMember = "Text";
+            this.resultStatusLookUpEdit.Name = "resultStatusLookUpEdit";
+            this.resultStatusLookUpEdit.NullText = "";
+            this.resultStatusLookUpEdit.ValueMember = "Value";
             // 
             // plateThickness
             // 
@@ -1559,9 +1558,9 @@
             ((System.ComponentModel.ISupportInitialize)(this.inspectionOperation)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.inspectionsGridView)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.testResultValue)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.resultStatusLookUpEdit)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.inspectorsPopupContainerEdit)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.inspectionCodeLookUpEdit)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.resultStatusLookUpEdit)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.plateThickness.Properties)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.plateNumber.Properties)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.shippedDate.Properties)).EndInit();

--- a/src/PrizmMainProject/Forms/PipeMill/NewEdit/MillPipeNewEditXtraForm.cs
+++ b/src/PrizmMainProject/Forms/PipeMill/NewEdit/MillPipeNewEditXtraForm.cs
@@ -967,6 +967,17 @@ namespace Prizm.Main.Forms.PipeMill.NewEdit
                     e.DisplayText = localizedAllPipeTestResultStatus[(int)result - 1]; //-1 because we skip 0
                 }
             }
+            if (e.Column.Name == expectedResultGridColumn.Name)
+            {
+                PipeTestResult pipeTestResult = inspectionsGridView.GetRow(e.ListSourceRowIndex) as PipeTestResult;
+                if (pipeTestResult != null)
+                {
+                    if (pipeTestResult.Operation.ResultType == PipeTestResultType.Boolean && pipeTestResult.Operation.BoolExpected == true)
+                    { e.DisplayText = Program.LanguageManager.GetString(StringResources.Yes); }
+                    if (pipeTestResult.Operation.ResultType == PipeTestResultType.Boolean && pipeTestResult.Operation.BoolExpected == false)
+                    { e.DisplayText = Program.LanguageManager.GetString(StringResources.No); }
+                }
+            }
         }
     }
 }

--- a/src/PrizmMainProject/Forms/PipeMill/NewEdit/MillPipeNewEditXtraForm.cs
+++ b/src/PrizmMainProject/Forms/PipeMill/NewEdit/MillPipeNewEditXtraForm.cs
@@ -50,6 +50,7 @@ namespace Prizm.Main.Forms.PipeMill.NewEdit
         private ExternalFilesXtraForm filesForm = null;
         // do NOT re-create it because reference passed to localization item. Clean it instead.
         private List<string> localizedAllPipeMillStatus = new List<string>();
+        private List<string> localizedAllPipeTestResultStatus= new List<string>();
         private PipeMillStatus originalStatus = PipeMillStatus.Undefined;
         private void UpdateTextEdit()
         {
@@ -132,9 +133,12 @@ namespace Prizm.Main.Forms.PipeMill.NewEdit
         {
             foreach(var item in EnumWrapper<PipeMillStatus>.EnumerateItems())
             {
+                localizedAllPipeTestResultStatus.Add(item.Item2);
+            }
+            foreach (var item in EnumWrapper<PipeTestResultStatus>.EnumerateItems(skip0:true))
+            {
                 localizedAllPipeMillStatus.Add(item.Item2);
             }
-
             BindCommands();
             BindToViewModel();
             viewModel.PropertyChanged += (s, eve) => IsModified = true;
@@ -372,7 +376,11 @@ namespace Prizm.Main.Forms.PipeMill.NewEdit
                             StringResources.NewEditPipe_PipeStatusStocked.Id, 
                             StringResources.NewEditPipe_PipeStatusShipped.Id} ),
 
-
+                    //grid enums
+                    new LocalizedItem (inspectionsGridView, localizedAllPipeTestResultStatus, new string [] { StringResources.PipeTestResultStatus_Scheduled.Id,
+                                                                                                              StringResources.PipeTestResultStatus_Passed.Id,
+                                                                                                              StringResources.PipeTestResultStatus_Failed.Id,
+                                                                                                              StringResources.PipeTestResultStatus_Repair.Id})
                     // other
                 };
         }
@@ -947,6 +955,18 @@ namespace Prizm.Main.Forms.PipeMill.NewEdit
             }
 
             return inspectionForm;
+        }
+
+        private void inspectionsGridView_CustomColumnDisplayText(object sender, CustomColumnDisplayTextEventArgs e)
+        {
+            if (e.Column.Name == inspectionResultGridColumn.Name && e.Value != null)
+            {
+                PipeTestResultStatus result;
+                if (Enum.TryParse<PipeTestResultStatus>(e.Value.ToString(), out result))
+                {
+                    e.DisplayText = localizedAllPipeTestResultStatus[(int)result - 1]; //-1 because we skip 0
+                }
+            }
         }
     }
 }

--- a/src/PrizmMainProject/Forms/Reports/Mill/MillReportsXtraForm.cs
+++ b/src/PrizmMainProject/Forms/Reports/Mill/MillReportsXtraForm.cs
@@ -103,7 +103,10 @@ namespace Prizm.Main.Forms.Reports.Mill
                     StringResources.MillReport_TypeByProduced.Id, 
                     StringResources.MillReport_TypeGeneral.Id }),
 
-                //new LocalizedItem(statuses, new string[] { "", "", "", "" }),
+                new LocalizedItem(statuses, new string[] { StringResources.PipeTestResultStatus_Scheduled.Id,
+                                                           StringResources.PipeTestResultStatus_Passed.Id,
+                                                           StringResources.PipeTestResultStatus_Failed.Id,
+                                                           StringResources.PipeTestResultStatus_Repair.Id }),
             };
         }
 

--- a/src/PrizmMainProject/Forms/Settings/SettingsXtraForm.Designer.cs
+++ b/src/PrizmMainProject/Forms/Settings/SettingsXtraForm.Designer.cs
@@ -29,7 +29,6 @@ namespace Prizm.Main.Forms.Settings
         /// </summary>
         private void InitializeComponent()
         {
-            this.components = new System.ComponentModel.Container();
             DevExpress.Utils.SerializableAppearanceObject serializableAppearanceObject1 = new DevExpress.Utils.SerializableAppearanceObject();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(SettingsXtraForm));
             this.pipesSizeList = new DevExpress.XtraGrid.GridControl();
@@ -38,18 +37,18 @@ namespace Prizm.Main.Forms.Settings
             this.typeRepositoryTextEdit = new DevExpress.XtraEditors.Repository.RepositoryItemTextEdit();
             this.isActiveGridColumn = new DevExpress.XtraGrid.Columns.GridColumn();
             this.gridControlPermission = new DevExpress.XtraGrid.GridControl();
-            this.permissionsBindingSource = new System.Windows.Forms.BindingSource(this.components);
+            this.permissionsBindingSource = new System.Windows.Forms.BindingSource();
             this.gridViewPermissions = new DevExpress.XtraGrid.Views.Grid.GridView();
             this.colPermissionDesc = new DevExpress.XtraGrid.Columns.GridColumn();
             this.gridControl1 = new DevExpress.XtraGrid.GridControl();
-            this.rolesBindingSource = new System.Windows.Forms.BindingSource(this.components);
+            this.rolesBindingSource = new System.Windows.Forms.BindingSource();
             this.gridViewRole = new DevExpress.XtraGrid.Views.Grid.GridView();
             this.colRoleSetupName = new DevExpress.XtraGrid.Columns.GridColumn();
             this.roleNameRepositoryItemTextEdit1 = new DevExpress.XtraEditors.Repository.RepositoryItemTextEdit();
             this.colDesc = new DevExpress.XtraGrid.Columns.GridColumn();
             this.roleDescriptionRepositoryItemTextEdit1 = new DevExpress.XtraEditors.Repository.RepositoryItemTextEdit();
             this.gridControlRoles = new DevExpress.XtraGrid.GridControl();
-            this.usersBindingSource = new System.Windows.Forms.BindingSource(this.components);
+            this.usersBindingSource = new System.Windows.Forms.BindingSource();
             this.gridViewRoles = new DevExpress.XtraGrid.Views.Grid.GridView();
             this.colRoleName = new DevExpress.XtraGrid.Columns.GridColumn();
             this.colRoleDesc = new DevExpress.XtraGrid.Columns.GridColumn();
@@ -154,14 +153,12 @@ namespace Prizm.Main.Forms.Settings
             this.millName = new DevExpress.XtraEditors.TextEdit();
             this.projectTitle = new DevExpress.XtraEditors.TextEdit();
             this.inspectionOperation = new DevExpress.XtraGrid.GridControl();
-            this.inspectionBindingSource = new System.Windows.Forms.BindingSource(this.components);
+            this.inspectionBindingSource = new System.Windows.Forms.BindingSource();
             this.inspectionView = new DevExpress.XtraGrid.Views.Grid.GridView();
             this.inspectionCodeGridColumn = new DevExpress.XtraGrid.Columns.GridColumn();
             this.inspectionNameGridColumn = new DevExpress.XtraGrid.Columns.GridColumn();
             this.controlTypeGridColumn = new DevExpress.XtraGrid.Columns.GridColumn();
-            this.controlTypeItems = new DevExpress.XtraEditors.Repository.RepositoryItemLookUpEdit();
             this.resultTypeGridColumn = new DevExpress.XtraGrid.Columns.GridColumn();
-            this.resultTypeItems = new DevExpress.XtraEditors.Repository.RepositoryItemLookUpEdit();
             this.boolExpectedGridColumn = new DevExpress.XtraGrid.Columns.GridColumn();
             this.minExpectedGridColumn = new DevExpress.XtraGrid.Columns.GridColumn();
             this.maxExpectedGridColumn = new DevExpress.XtraGrid.Columns.GridColumn();
@@ -172,6 +169,8 @@ namespace Prizm.Main.Forms.Settings
             this.repositoryItemsСategory = new DevExpress.XtraEditors.Repository.RepositoryItemGridLookUpEdit();
             this.repositoryItemsСategoryView = new DevExpress.XtraGrid.Views.Grid.GridView();
             this.CategoryName = new DevExpress.XtraGrid.Columns.GridColumn();
+            this.controlTypeItems = new DevExpress.XtraEditors.Repository.RepositoryItemLookUpEdit();
+            this.resultTypeItems = new DevExpress.XtraEditors.Repository.RepositoryItemLookUpEdit();
             this.plateManufacturersList = new DevExpress.XtraGrid.GridControl();
             this.plateManufacturersListView = new DevExpress.XtraGrid.Views.Grid.GridView();
             this.plateManufacturerGridColumn = new DevExpress.XtraGrid.Columns.GridColumn();
@@ -182,13 +181,8 @@ namespace Prizm.Main.Forms.Settings
             this.seamType = new DevExpress.XtraEditors.ComboBoxEdit();
             this.RootGroup = new DevExpress.XtraLayout.LayoutControlGroup();
             this.tabbedControlGroup = new DevExpress.XtraLayout.TabbedControlGroup();
-            this.inspectorsLayoutControlGroup = new DevExpress.XtraLayout.LayoutControlGroup();
-            this.inspectorLayoutControlGroup = new DevExpress.XtraLayout.LayoutControlGroup();
-            this.certificateLayoutControlItem = new DevExpress.XtraLayout.LayoutControlItem();
-            this.inspectorsLayoutControlItem = new DevExpress.XtraLayout.LayoutControlItem();
-            this.certificateTypeLayoutControlGroup = new DevExpress.XtraLayout.LayoutControlGroup();
-            this.certTypeListLayoutControlItem = new DevExpress.XtraLayout.LayoutControlItem();
-            this.inspectorSplitterItem = new DevExpress.XtraLayout.SplitterItem();
+            this.lineLayoutControlGroup = new DevExpress.XtraLayout.LayoutControlGroup();
+            this.jointOperationLayoutControlItem = new DevExpress.XtraLayout.LayoutControlItem();
             this.projectLayoutControlGroup = new DevExpress.XtraLayout.LayoutControlGroup();
             this.commonParamsLayoutControlGroup = new DevExpress.XtraLayout.LayoutControlGroup();
             this.projectTitleLayoutControlItem = new DevExpress.XtraLayout.LayoutControlItem();
@@ -215,14 +209,19 @@ namespace Prizm.Main.Forms.Settings
             this.addTestButtonLayout = new DevExpress.XtraLayout.LayoutControlItem();
             this.testButtonsEmptySpace = new DevExpress.XtraLayout.EmptySpaceItem();
             this.editTestButtonLayout = new DevExpress.XtraLayout.LayoutControlItem();
-            this.lineLayoutControlGroup = new DevExpress.XtraLayout.LayoutControlGroup();
-            this.jointOperationLayoutControlItem = new DevExpress.XtraLayout.LayoutControlItem();
             this.partsLayoutControlGroup = new DevExpress.XtraLayout.LayoutControlGroup();
             this.partsTypeLayoutControlItem = new DevExpress.XtraLayout.LayoutControlItem();
             this.emptySpaceItem = new DevExpress.XtraLayout.EmptySpaceItem();
             this.partsSplitterItem = new DevExpress.XtraLayout.SplitterItem();
             this.weldersLayoutControlGroup = new DevExpress.XtraLayout.LayoutControlGroup();
             this.weldersLayoutControlItem = new DevExpress.XtraLayout.LayoutControlItem();
+            this.inspectorsLayoutControlGroup = new DevExpress.XtraLayout.LayoutControlGroup();
+            this.inspectorLayoutControlGroup = new DevExpress.XtraLayout.LayoutControlGroup();
+            this.certificateLayoutControlItem = new DevExpress.XtraLayout.LayoutControlItem();
+            this.inspectorsLayoutControlItem = new DevExpress.XtraLayout.LayoutControlItem();
+            this.certificateTypeLayoutControlGroup = new DevExpress.XtraLayout.LayoutControlGroup();
+            this.certTypeListLayoutControlItem = new DevExpress.XtraLayout.LayoutControlItem();
+            this.inspectorSplitterItem = new DevExpress.XtraLayout.SplitterItem();
             this.usersLayoutControlGroup = new DevExpress.XtraLayout.LayoutControlGroup();
             this.userLayoutControlItem = new DevExpress.XtraLayout.LayoutControlItem();
             this.roleLayoutControlItem = new DevExpress.XtraLayout.LayoutControlItem();
@@ -236,14 +235,14 @@ namespace Prizm.Main.Forms.Settings
             this.buttonEmptySpaceItem = new DevExpress.XtraLayout.EmptySpaceItem();
             this.editDictionary = new DevExpress.XtraGrid.Columns.GridColumn();
             this.editItem = new DevExpress.XtraEditors.Repository.RepositoryItemButtonEdit();
-            this.userBindingSource = new System.Windows.Forms.BindingSource(this.components);
-            this.roleBindingSource = new System.Windows.Forms.BindingSource(this.components);
-            this.pipeMillSizeTypeBindingSource = new System.Windows.Forms.BindingSource(this.components);
-            this.inspectorBindingSource = new System.Windows.Forms.BindingSource(this.components);
-            this.inspectorCertificateBindingSource = new System.Windows.Forms.BindingSource(this.components);
-            this.jointOperationsBindingSource = new System.Windows.Forms.BindingSource(this.components);
-            this.dxValidationProvider = new DevExpress.XtraEditors.DXErrorProvider.DXValidationProvider(this.components);
-            this.CurrentPipeMillSizeTypeBindingSource = new System.Windows.Forms.BindingSource(this.components);
+            this.userBindingSource = new System.Windows.Forms.BindingSource();
+            this.roleBindingSource = new System.Windows.Forms.BindingSource();
+            this.pipeMillSizeTypeBindingSource = new System.Windows.Forms.BindingSource();
+            this.inspectorBindingSource = new System.Windows.Forms.BindingSource();
+            this.inspectorCertificateBindingSource = new System.Windows.Forms.BindingSource();
+            this.jointOperationsBindingSource = new System.Windows.Forms.BindingSource();
+            this.dxValidationProvider = new DevExpress.XtraEditors.DXErrorProvider.DXValidationProvider();
+            this.CurrentPipeMillSizeTypeBindingSource = new System.Windows.Forms.BindingSource();
             ((System.ComponentModel.ISupportInitialize)(this.pipesSizeList)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.pipesSizeListGridView)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.typeRepositoryTextEdit)).BeginInit();
@@ -313,11 +312,11 @@ namespace Prizm.Main.Forms.Settings
             ((System.ComponentModel.ISupportInitialize)(this.inspectionOperation)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.inspectionBindingSource)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.inspectionView)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.controlTypeItems)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.resultTypeItems)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.isRequired)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.repositoryItemsСategory)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.repositoryItemsСategoryView)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.controlTypeItems)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.resultTypeItems)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.plateManufacturersList)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.plateManufacturersListView)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.manufacturerRepositoryTextEdit)).BeginInit();
@@ -327,13 +326,8 @@ namespace Prizm.Main.Forms.Settings
             ((System.ComponentModel.ISupportInitialize)(this.seamType.Properties)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.RootGroup)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.tabbedControlGroup)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.inspectorsLayoutControlGroup)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.inspectorLayoutControlGroup)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.certificateLayoutControlItem)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.inspectorsLayoutControlItem)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.certificateTypeLayoutControlGroup)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.certTypeListLayoutControlItem)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.inspectorSplitterItem)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.lineLayoutControlGroup)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.jointOperationLayoutControlItem)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.projectLayoutControlGroup)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.commonParamsLayoutControlGroup)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.projectTitleLayoutControlItem)).BeginInit();
@@ -360,14 +354,19 @@ namespace Prizm.Main.Forms.Settings
             ((System.ComponentModel.ISupportInitialize)(this.addTestButtonLayout)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.testButtonsEmptySpace)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.editTestButtonLayout)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.lineLayoutControlGroup)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.jointOperationLayoutControlItem)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.partsLayoutControlGroup)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.partsTypeLayoutControlItem)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.emptySpaceItem)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.partsSplitterItem)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.weldersLayoutControlGroup)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.weldersLayoutControlItem)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.inspectorsLayoutControlGroup)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.inspectorLayoutControlGroup)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.certificateLayoutControlItem)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.inspectorsLayoutControlItem)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.certificateTypeLayoutControlGroup)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.certTypeListLayoutControlItem)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.inspectorSplitterItem)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.usersLayoutControlGroup)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.userLayoutControlItem)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.roleLayoutControlItem)).BeginInit();
@@ -1308,12 +1307,10 @@ namespace Prizm.Main.Forms.Settings
             this.jointOperationTypeLookUpEdit.AutoHeight = false;
             this.jointOperationTypeLookUpEdit.Buttons.AddRange(new DevExpress.XtraEditors.Controls.EditorButton[] {
             new DevExpress.XtraEditors.Controls.EditorButton(DevExpress.XtraEditors.Controls.ButtonPredefines.Combo)});
-            this.jointOperationTypeLookUpEdit.Columns.AddRange(new DevExpress.XtraEditors.Controls.LookUpColumnInfo[] {
-            new DevExpress.XtraEditors.Controls.LookUpColumnInfo("Text", "Тип операции")});
-            this.jointOperationTypeLookUpEdit.DisplayMember = "Text";
             this.jointOperationTypeLookUpEdit.Name = "jointOperationTypeLookUpEdit";
             this.jointOperationTypeLookUpEdit.NullText = "";
-            this.jointOperationTypeLookUpEdit.ValueMember = "Value";
+            this.jointOperationTypeLookUpEdit.EditValueChanged += new System.EventHandler(this.jointOperationTypeLookUpEdit_EditValueChanged);
+            this.jointOperationTypeLookUpEdit.CustomDisplayText += new DevExpress.XtraEditors.Controls.CustomDisplayTextEventHandler(this.jointOperationTypeLookUpEdit_CustomDisplayText);
             // 
             // testHasAcceptedGridColumn
             // 
@@ -1694,6 +1691,7 @@ namespace Prizm.Main.Forms.Settings
             this.inspectionView.InvalidRowException += new DevExpress.XtraGrid.Views.Base.InvalidRowExceptionEventHandler(this.HandleInvalidRowException);
             this.inspectionView.BeforeLeaveRow += new DevExpress.XtraGrid.Views.Base.RowAllowEventHandler(this.inspectionView_BeforeLeaveRow);
             this.inspectionView.ValidateRow += new DevExpress.XtraGrid.Views.Base.ValidateRowEventHandler(this.inspectionView_ValidateRow);
+            this.inspectionView.CustomColumnDisplayText += new DevExpress.XtraGrid.Views.Base.CustomColumnDisplayTextEventHandler(this.inspectionView_CustomColumnDisplayText);
             this.inspectionView.KeyDown += new System.Windows.Forms.KeyEventHandler(this.inspectionView_KeyDown);
             // 
             // inspectionCodeGridColumn
@@ -1719,7 +1717,6 @@ namespace Prizm.Main.Forms.Settings
             // controlTypeGridColumn
             // 
             this.controlTypeGridColumn.Caption = "Вид контроля";
-            this.controlTypeGridColumn.ColumnEdit = this.controlTypeItems;
             this.controlTypeGridColumn.FieldName = "ControlType";
             this.controlTypeGridColumn.Name = "controlTypeGridColumn";
             this.controlTypeGridColumn.OptionsColumn.AllowEdit = false;
@@ -1727,42 +1724,15 @@ namespace Prizm.Main.Forms.Settings
             this.controlTypeGridColumn.VisibleIndex = 3;
             this.controlTypeGridColumn.Width = 120;
             // 
-            // controlTypeItems
-            // 
-            this.controlTypeItems.AutoHeight = false;
-            this.controlTypeItems.Buttons.AddRange(new DevExpress.XtraEditors.Controls.EditorButton[] {
-            new DevExpress.XtraEditors.Controls.EditorButton(DevExpress.XtraEditors.Controls.ButtonPredefines.Combo)});
-            this.controlTypeItems.Columns.AddRange(new DevExpress.XtraEditors.Controls.LookUpColumnInfo[] {
-            new DevExpress.XtraEditors.Controls.LookUpColumnInfo("Text", "Вид контроля")});
-            this.controlTypeItems.DisplayMember = "Text";
-            this.controlTypeItems.DropDownRows = 4;
-            this.controlTypeItems.Name = "controlTypeItems";
-            this.controlTypeItems.NullText = "";
-            this.controlTypeItems.ValueMember = "Value";
-            // 
             // resultTypeGridColumn
             // 
             this.resultTypeGridColumn.Caption = "Тип результата";
-            this.resultTypeGridColumn.ColumnEdit = this.resultTypeItems;
             this.resultTypeGridColumn.FieldName = "ResultType";
             this.resultTypeGridColumn.Name = "resultTypeGridColumn";
             this.resultTypeGridColumn.OptionsColumn.AllowEdit = false;
             this.resultTypeGridColumn.Visible = true;
             this.resultTypeGridColumn.VisibleIndex = 4;
             this.resultTypeGridColumn.Width = 120;
-            // 
-            // resultTypeItems
-            // 
-            this.resultTypeItems.AutoHeight = false;
-            this.resultTypeItems.Buttons.AddRange(new DevExpress.XtraEditors.Controls.EditorButton[] {
-            new DevExpress.XtraEditors.Controls.EditorButton(DevExpress.XtraEditors.Controls.ButtonPredefines.Combo)});
-            this.resultTypeItems.Columns.AddRange(new DevExpress.XtraEditors.Controls.LookUpColumnInfo[] {
-            new DevExpress.XtraEditors.Controls.LookUpColumnInfo("Text", "Тип результата")});
-            this.resultTypeItems.DisplayMember = "Text";
-            this.resultTypeItems.DropDownRows = 3;
-            this.resultTypeItems.Name = "resultTypeItems";
-            this.resultTypeItems.NullText = "";
-            this.resultTypeItems.ValueMember = "Value";
             // 
             // boolExpectedGridColumn
             // 
@@ -1864,6 +1834,32 @@ namespace Prizm.Main.Forms.Settings
             this.CategoryName.OptionsColumn.ShowCaption = false;
             this.CategoryName.Visible = true;
             this.CategoryName.VisibleIndex = 0;
+            // 
+            // controlTypeItems
+            // 
+            this.controlTypeItems.AutoHeight = false;
+            this.controlTypeItems.Buttons.AddRange(new DevExpress.XtraEditors.Controls.EditorButton[] {
+            new DevExpress.XtraEditors.Controls.EditorButton(DevExpress.XtraEditors.Controls.ButtonPredefines.Combo)});
+            this.controlTypeItems.Columns.AddRange(new DevExpress.XtraEditors.Controls.LookUpColumnInfo[] {
+            new DevExpress.XtraEditors.Controls.LookUpColumnInfo("Text", "Вид контроля")});
+            this.controlTypeItems.DisplayMember = "Text";
+            this.controlTypeItems.DropDownRows = 4;
+            this.controlTypeItems.Name = "controlTypeItems";
+            this.controlTypeItems.NullText = "";
+            this.controlTypeItems.ValueMember = "Value";
+            // 
+            // resultTypeItems
+            // 
+            this.resultTypeItems.AutoHeight = false;
+            this.resultTypeItems.Buttons.AddRange(new DevExpress.XtraEditors.Controls.EditorButton[] {
+            new DevExpress.XtraEditors.Controls.EditorButton(DevExpress.XtraEditors.Controls.ButtonPredefines.Combo)});
+            this.resultTypeItems.Columns.AddRange(new DevExpress.XtraEditors.Controls.LookUpColumnInfo[] {
+            new DevExpress.XtraEditors.Controls.LookUpColumnInfo("Text", "Тип результата")});
+            this.resultTypeItems.DisplayMember = "Text";
+            this.resultTypeItems.DropDownRows = 3;
+            this.resultTypeItems.Name = "resultTypeItems";
+            this.resultTypeItems.NullText = "";
+            this.resultTypeItems.ValueMember = "Value";
             // 
             // plateManufacturersList
             // 
@@ -1968,8 +1964,8 @@ namespace Prizm.Main.Forms.Settings
             this.tabbedControlGroup.CustomizationFormText = "Группа вкладок";
             this.tabbedControlGroup.Location = new System.Drawing.Point(0, 0);
             this.tabbedControlGroup.Name = "tabbedControlGroup";
-            this.tabbedControlGroup.SelectedTabPage = this.pipeLayoutControlGroup;
-            this.tabbedControlGroup.SelectedTabPageIndex = 1;
+            this.tabbedControlGroup.SelectedTabPage = this.lineLayoutControlGroup;
+            this.tabbedControlGroup.SelectedTabPageIndex = 2;
             this.tabbedControlGroup.Size = new System.Drawing.Size(1255, 504);
             this.tabbedControlGroup.TabPages.AddRange(new DevExpress.XtraLayout.BaseLayoutItem[] {
             this.projectLayoutControlGroup,
@@ -1982,84 +1978,26 @@ namespace Prizm.Main.Forms.Settings
             this.rolesLayoutControlGroup});
             this.tabbedControlGroup.Text = "Группа вкладок";
             // 
-            // inspectorsLayoutControlGroup
+            // lineLayoutControlGroup
             // 
-            this.inspectorsLayoutControlGroup.CustomizationFormText = "&Инспекторы";
-            this.inspectorsLayoutControlGroup.Items.AddRange(new DevExpress.XtraLayout.BaseLayoutItem[] {
-            this.inspectorLayoutControlGroup,
-            this.certificateTypeLayoutControlGroup,
-            this.inspectorSplitterItem});
-            this.inspectorsLayoutControlGroup.Location = new System.Drawing.Point(0, 0);
-            this.inspectorsLayoutControlGroup.Name = "inspectorsLayoutControlGroup";
-            this.inspectorsLayoutControlGroup.Size = new System.Drawing.Size(1231, 458);
-            this.inspectorsLayoutControlGroup.Text = "&Инспекторы";
+            this.lineLayoutControlGroup.CustomizationFormText = "Тру&бопровод";
+            this.lineLayoutControlGroup.Items.AddRange(new DevExpress.XtraLayout.BaseLayoutItem[] {
+            this.jointOperationLayoutControlItem});
+            this.lineLayoutControlGroup.Location = new System.Drawing.Point(0, 0);
+            this.lineLayoutControlGroup.Name = "lineLayoutControlGroup";
+            this.lineLayoutControlGroup.Size = new System.Drawing.Size(1231, 458);
+            this.lineLayoutControlGroup.Text = "Тру&бопровод";
             // 
-            // inspectorLayoutControlGroup
+            // jointOperationLayoutControlItem
             // 
-            this.inspectorLayoutControlGroup.CustomizationFormText = "Инспекторы";
-            this.inspectorLayoutControlGroup.Items.AddRange(new DevExpress.XtraLayout.BaseLayoutItem[] {
-            this.certificateLayoutControlItem,
-            this.inspectorsLayoutControlItem});
-            this.inspectorLayoutControlGroup.Location = new System.Drawing.Point(0, 0);
-            this.inspectorLayoutControlGroup.Name = "inspectorLayoutControlGroup";
-            this.inspectorLayoutControlGroup.Size = new System.Drawing.Size(870, 458);
-            this.inspectorLayoutControlGroup.Spacing = new DevExpress.XtraLayout.Utils.Padding(5, 5, 5, 5);
-            this.inspectorLayoutControlGroup.Text = "Инспекторы";
-            // 
-            // certificateLayoutControlItem
-            // 
-            this.certificateLayoutControlItem.Control = this.gridControlInspectorsCertificates;
-            this.certificateLayoutControlItem.CustomizationFormText = "Сертификаты";
-            this.certificateLayoutControlItem.Location = new System.Drawing.Point(384, 0);
-            this.certificateLayoutControlItem.Name = "certificateLayoutControlItem";
-            this.certificateLayoutControlItem.Size = new System.Drawing.Size(456, 409);
-            this.certificateLayoutControlItem.Spacing = new DevExpress.XtraLayout.Utils.Padding(5, 5, 5, 5);
-            this.certificateLayoutControlItem.Text = "Сертификаты";
-            this.certificateLayoutControlItem.TextLocation = DevExpress.Utils.Locations.Top;
-            this.certificateLayoutControlItem.TextSize = new System.Drawing.Size(312, 13);
-            // 
-            // inspectorsLayoutControlItem
-            // 
-            this.inspectorsLayoutControlItem.Control = this.gridControlInspectors;
-            this.inspectorsLayoutControlItem.CustomizationFormText = "Инспекторы";
-            this.inspectorsLayoutControlItem.Location = new System.Drawing.Point(0, 0);
-            this.inspectorsLayoutControlItem.Name = "inspectorsLayoutControlItem";
-            this.inspectorsLayoutControlItem.Size = new System.Drawing.Size(384, 409);
-            this.inspectorsLayoutControlItem.Spacing = new DevExpress.XtraLayout.Utils.Padding(5, 5, 5, 5);
-            this.inspectorsLayoutControlItem.Text = "Инспекторы";
-            this.inspectorsLayoutControlItem.TextLocation = DevExpress.Utils.Locations.Top;
-            this.inspectorsLayoutControlItem.TextSize = new System.Drawing.Size(312, 13);
-            // 
-            // certificateTypeLayoutControlGroup
-            // 
-            this.certificateTypeLayoutControlGroup.CustomizationFormText = "Типы сертификатов";
-            this.certificateTypeLayoutControlGroup.Items.AddRange(new DevExpress.XtraLayout.BaseLayoutItem[] {
-            this.certTypeListLayoutControlItem});
-            this.certificateTypeLayoutControlGroup.Location = new System.Drawing.Point(875, 0);
-            this.certificateTypeLayoutControlGroup.Name = "certificateTypeLayoutControlGroup";
-            this.certificateTypeLayoutControlGroup.Size = new System.Drawing.Size(356, 458);
-            this.certificateTypeLayoutControlGroup.Spacing = new DevExpress.XtraLayout.Utils.Padding(5, 5, 5, 5);
-            this.certificateTypeLayoutControlGroup.Text = "Типы сертификатов";
-            // 
-            // certTypeListLayoutControlItem
-            // 
-            this.certTypeListLayoutControlItem.Control = this.certificateTypes;
-            this.certTypeListLayoutControlItem.CustomizationFormText = "Список типов";
-            this.certTypeListLayoutControlItem.Location = new System.Drawing.Point(0, 0);
-            this.certTypeListLayoutControlItem.Name = "certTypeListLayoutControlItem";
-            this.certTypeListLayoutControlItem.Size = new System.Drawing.Size(326, 409);
-            this.certTypeListLayoutControlItem.Spacing = new DevExpress.XtraLayout.Utils.Padding(5, 5, 5, 5);
-            this.certTypeListLayoutControlItem.Text = "Список типов";
-            this.certTypeListLayoutControlItem.TextLocation = DevExpress.Utils.Locations.Top;
-            this.certTypeListLayoutControlItem.TextSize = new System.Drawing.Size(312, 13);
-            // 
-            // inspectorSplitterItem
-            // 
-            this.inspectorSplitterItem.AllowHotTrack = true;
-            this.inspectorSplitterItem.CustomizationFormText = "Разделитель";
-            this.inspectorSplitterItem.Location = new System.Drawing.Point(870, 0);
-            this.inspectorSplitterItem.Name = "inspectorSplitterItem";
-            this.inspectorSplitterItem.Size = new System.Drawing.Size(5, 458);
+            this.jointOperationLayoutControlItem.Control = this.jointOperations;
+            this.jointOperationLayoutControlItem.CustomizationFormText = "Набор операций - условия приемки стыка для спуска";
+            this.jointOperationLayoutControlItem.Location = new System.Drawing.Point(0, 0);
+            this.jointOperationLayoutControlItem.Name = "jointOperationLayoutControlItem";
+            this.jointOperationLayoutControlItem.Size = new System.Drawing.Size(1231, 458);
+            this.jointOperationLayoutControlItem.Text = "Набор операций - условия приемки стыка для спуска";
+            this.jointOperationLayoutControlItem.TextLocation = DevExpress.Utils.Locations.Top;
+            this.jointOperationLayoutControlItem.TextSize = new System.Drawing.Size(312, 13);
             // 
             // projectLayoutControlGroup
             // 
@@ -2387,27 +2325,6 @@ namespace Prizm.Main.Forms.Settings
             this.editTestButtonLayout.TextSize = new System.Drawing.Size(0, 0);
             this.editTestButtonLayout.TextVisible = false;
             // 
-            // lineLayoutControlGroup
-            // 
-            this.lineLayoutControlGroup.CustomizationFormText = "Тру&бопровод";
-            this.lineLayoutControlGroup.Items.AddRange(new DevExpress.XtraLayout.BaseLayoutItem[] {
-            this.jointOperationLayoutControlItem});
-            this.lineLayoutControlGroup.Location = new System.Drawing.Point(0, 0);
-            this.lineLayoutControlGroup.Name = "lineLayoutControlGroup";
-            this.lineLayoutControlGroup.Size = new System.Drawing.Size(1231, 458);
-            this.lineLayoutControlGroup.Text = "Тру&бопровод";
-            // 
-            // jointOperationLayoutControlItem
-            // 
-            this.jointOperationLayoutControlItem.Control = this.jointOperations;
-            this.jointOperationLayoutControlItem.CustomizationFormText = "Набор операций - условия приемки стыка для спуска";
-            this.jointOperationLayoutControlItem.Location = new System.Drawing.Point(0, 0);
-            this.jointOperationLayoutControlItem.Name = "jointOperationLayoutControlItem";
-            this.jointOperationLayoutControlItem.Size = new System.Drawing.Size(1231, 458);
-            this.jointOperationLayoutControlItem.Text = "Набор операций - условия приемки стыка для спуска";
-            this.jointOperationLayoutControlItem.TextLocation = DevExpress.Utils.Locations.Top;
-            this.jointOperationLayoutControlItem.TextSize = new System.Drawing.Size(312, 13);
-            // 
             // partsLayoutControlGroup
             // 
             this.partsLayoutControlGroup.CustomizationFormText = "Комплектую&щие";
@@ -2469,6 +2386,85 @@ namespace Prizm.Main.Forms.Settings
             this.weldersLayoutControlItem.Text = "Сварщики";
             this.weldersLayoutControlItem.TextSize = new System.Drawing.Size(0, 0);
             this.weldersLayoutControlItem.TextVisible = false;
+            // 
+            // inspectorsLayoutControlGroup
+            // 
+            this.inspectorsLayoutControlGroup.CustomizationFormText = "&Инспекторы";
+            this.inspectorsLayoutControlGroup.Items.AddRange(new DevExpress.XtraLayout.BaseLayoutItem[] {
+            this.inspectorLayoutControlGroup,
+            this.certificateTypeLayoutControlGroup,
+            this.inspectorSplitterItem});
+            this.inspectorsLayoutControlGroup.Location = new System.Drawing.Point(0, 0);
+            this.inspectorsLayoutControlGroup.Name = "inspectorsLayoutControlGroup";
+            this.inspectorsLayoutControlGroup.Size = new System.Drawing.Size(1231, 458);
+            this.inspectorsLayoutControlGroup.Text = "&Инспекторы";
+            // 
+            // inspectorLayoutControlGroup
+            // 
+            this.inspectorLayoutControlGroup.CustomizationFormText = "Инспекторы";
+            this.inspectorLayoutControlGroup.Items.AddRange(new DevExpress.XtraLayout.BaseLayoutItem[] {
+            this.certificateLayoutControlItem,
+            this.inspectorsLayoutControlItem});
+            this.inspectorLayoutControlGroup.Location = new System.Drawing.Point(0, 0);
+            this.inspectorLayoutControlGroup.Name = "inspectorLayoutControlGroup";
+            this.inspectorLayoutControlGroup.Size = new System.Drawing.Size(870, 458);
+            this.inspectorLayoutControlGroup.Spacing = new DevExpress.XtraLayout.Utils.Padding(5, 5, 5, 5);
+            this.inspectorLayoutControlGroup.Text = "Инспекторы";
+            // 
+            // certificateLayoutControlItem
+            // 
+            this.certificateLayoutControlItem.Control = this.gridControlInspectorsCertificates;
+            this.certificateLayoutControlItem.CustomizationFormText = "Сертификаты";
+            this.certificateLayoutControlItem.Location = new System.Drawing.Point(384, 0);
+            this.certificateLayoutControlItem.Name = "certificateLayoutControlItem";
+            this.certificateLayoutControlItem.Size = new System.Drawing.Size(456, 409);
+            this.certificateLayoutControlItem.Spacing = new DevExpress.XtraLayout.Utils.Padding(5, 5, 5, 5);
+            this.certificateLayoutControlItem.Text = "Сертификаты";
+            this.certificateLayoutControlItem.TextLocation = DevExpress.Utils.Locations.Top;
+            this.certificateLayoutControlItem.TextSize = new System.Drawing.Size(312, 13);
+            // 
+            // inspectorsLayoutControlItem
+            // 
+            this.inspectorsLayoutControlItem.Control = this.gridControlInspectors;
+            this.inspectorsLayoutControlItem.CustomizationFormText = "Инспекторы";
+            this.inspectorsLayoutControlItem.Location = new System.Drawing.Point(0, 0);
+            this.inspectorsLayoutControlItem.Name = "inspectorsLayoutControlItem";
+            this.inspectorsLayoutControlItem.Size = new System.Drawing.Size(384, 409);
+            this.inspectorsLayoutControlItem.Spacing = new DevExpress.XtraLayout.Utils.Padding(5, 5, 5, 5);
+            this.inspectorsLayoutControlItem.Text = "Инспекторы";
+            this.inspectorsLayoutControlItem.TextLocation = DevExpress.Utils.Locations.Top;
+            this.inspectorsLayoutControlItem.TextSize = new System.Drawing.Size(312, 13);
+            // 
+            // certificateTypeLayoutControlGroup
+            // 
+            this.certificateTypeLayoutControlGroup.CustomizationFormText = "Типы сертификатов";
+            this.certificateTypeLayoutControlGroup.Items.AddRange(new DevExpress.XtraLayout.BaseLayoutItem[] {
+            this.certTypeListLayoutControlItem});
+            this.certificateTypeLayoutControlGroup.Location = new System.Drawing.Point(875, 0);
+            this.certificateTypeLayoutControlGroup.Name = "certificateTypeLayoutControlGroup";
+            this.certificateTypeLayoutControlGroup.Size = new System.Drawing.Size(356, 458);
+            this.certificateTypeLayoutControlGroup.Spacing = new DevExpress.XtraLayout.Utils.Padding(5, 5, 5, 5);
+            this.certificateTypeLayoutControlGroup.Text = "Типы сертификатов";
+            // 
+            // certTypeListLayoutControlItem
+            // 
+            this.certTypeListLayoutControlItem.Control = this.certificateTypes;
+            this.certTypeListLayoutControlItem.CustomizationFormText = "Список типов";
+            this.certTypeListLayoutControlItem.Location = new System.Drawing.Point(0, 0);
+            this.certTypeListLayoutControlItem.Name = "certTypeListLayoutControlItem";
+            this.certTypeListLayoutControlItem.Size = new System.Drawing.Size(326, 409);
+            this.certTypeListLayoutControlItem.Spacing = new DevExpress.XtraLayout.Utils.Padding(5, 5, 5, 5);
+            this.certTypeListLayoutControlItem.Text = "Список типов";
+            this.certTypeListLayoutControlItem.TextLocation = DevExpress.Utils.Locations.Top;
+            this.certTypeListLayoutControlItem.TextSize = new System.Drawing.Size(312, 13);
+            // 
+            // inspectorSplitterItem
+            // 
+            this.inspectorSplitterItem.AllowHotTrack = true;
+            this.inspectorSplitterItem.CustomizationFormText = "Разделитель";
+            this.inspectorSplitterItem.Location = new System.Drawing.Point(870, 0);
+            this.inspectorSplitterItem.Name = "inspectorSplitterItem";
+            this.inspectorSplitterItem.Size = new System.Drawing.Size(5, 458);
             // 
             // usersLayoutControlGroup
             // 
@@ -2692,11 +2688,11 @@ namespace Prizm.Main.Forms.Settings
             ((System.ComponentModel.ISupportInitialize)(this.inspectionOperation)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.inspectionBindingSource)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.inspectionView)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.controlTypeItems)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.resultTypeItems)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.isRequired)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.repositoryItemsСategory)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.repositoryItemsСategoryView)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.controlTypeItems)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.resultTypeItems)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.plateManufacturersList)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.plateManufacturersListView)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.manufacturerRepositoryTextEdit)).EndInit();
@@ -2706,13 +2702,8 @@ namespace Prizm.Main.Forms.Settings
             ((System.ComponentModel.ISupportInitialize)(this.seamType.Properties)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.RootGroup)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.tabbedControlGroup)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.inspectorsLayoutControlGroup)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.inspectorLayoutControlGroup)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.certificateLayoutControlItem)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.inspectorsLayoutControlItem)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.certificateTypeLayoutControlGroup)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.certTypeListLayoutControlItem)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.inspectorSplitterItem)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.lineLayoutControlGroup)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.jointOperationLayoutControlItem)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.projectLayoutControlGroup)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.commonParamsLayoutControlGroup)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.projectTitleLayoutControlItem)).EndInit();
@@ -2739,14 +2730,19 @@ namespace Prizm.Main.Forms.Settings
             ((System.ComponentModel.ISupportInitialize)(this.addTestButtonLayout)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.testButtonsEmptySpace)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.editTestButtonLayout)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.lineLayoutControlGroup)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.jointOperationLayoutControlItem)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.partsLayoutControlGroup)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.partsTypeLayoutControlItem)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.emptySpaceItem)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.partsSplitterItem)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.weldersLayoutControlGroup)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.weldersLayoutControlItem)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.inspectorsLayoutControlGroup)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.inspectorLayoutControlGroup)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.certificateLayoutControlItem)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.inspectorsLayoutControlItem)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.certificateTypeLayoutControlGroup)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.certTypeListLayoutControlItem)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.inspectorSplitterItem)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.usersLayoutControlGroup)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.userLayoutControlItem)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.roleLayoutControlItem)).EndInit();

--- a/src/PrizmMainProject/Forms/Settings/SettingsXtraForm.cs
+++ b/src/PrizmMainProject/Forms/Settings/SettingsXtraForm.cs
@@ -42,7 +42,9 @@ namespace Prizm.Main.Forms.Settings
         private bool newPipeSizeType = false;
         ICommandManager commandManager = new CommandManager();
         private List<string> pipeSizesDuplicates;
-
+        private List<string> localizedPipeTestControlTypes = new List<string>();
+        private List<string> localizedPipeTestResultTypes = new List<string>();
+        private List<string> localizedJointOperationTypes = new List<string>();
         public SettingsXtraForm()
         {
             InitializeComponent();
@@ -61,6 +63,18 @@ namespace Prizm.Main.Forms.Settings
 
         private void SettingsXtraForm_Load(object sender, EventArgs e)
         {
+            foreach (var item in EnumWrapper<PipeTestControlType>.EnumerateItems(skip0:true))
+            {
+                localizedPipeTestControlTypes.Add(item.Item2);
+            }
+            foreach (var item in EnumWrapper<PipeTestResultType>.EnumerateItems(skip0: true))
+            {
+                localizedPipeTestResultTypes.Add(item.Item2);
+            }
+            foreach (var item in EnumWrapper<JointOperationType>.EnumerateItems(skip0: true))
+            {
+                localizedJointOperationTypes.Add(item.Item2);
+            }
             pipeNumberMaskRulesLabel.Text = Program.LanguageManager.GetString(StringResources.Mask_Label);
             viewModel.ModifiableView = this;
             viewModel.validatableView = this;
@@ -331,6 +345,21 @@ namespace Prizm.Main.Forms.Settings
 
                 new LocalizedItem(saveButton, "Settings_SaveButton"),
                 new LocalizedItem(closeButton, "Settings_CloseButton"),
+                
+                //grid columns with enums
+                new LocalizedItem(inspectionView, localizedPipeTestControlTypes, new string [] {StringResources.ControlTypeWitness.Id,
+                                                                                         StringResources.ControlTypeReview.Id,
+                                                                                         StringResources.ControlTypeMonitor.Id,
+                                                                                         StringResources.ControlTypeHold.Id}),
+                new LocalizedItem (inspectionView, localizedPipeTestResultTypes, new string [] {StringResources.TestResultTypeBoolean.Id,
+                                                                                                  StringResources.TestResultTypeRange.Id,
+                                                                                                  StringResources.TestResultTypeString.Id }),
+                //repository lookup edit
+                new LocalizedItem(jointOperationTypeLookUpEdit, localizedJointOperationTypes, new string[] {StringResources.JointOperationType_Test.Id,
+                                                                                                            StringResources.JointOperationType_Action.Id,
+                                                                                                            StringResources.JointOperationType_Weld.Id,
+                                                                                                            StringResources.JointOperationType_Withdraw.Id})
+                                                                                         
             };
         }
 
@@ -1373,6 +1402,47 @@ namespace Prizm.Main.Forms.Settings
         private void certificateTypesView_ValidateRow(object sender, ValidateRowEventArgs e)
         {
             ValidateName(certificateTypesView, certificateNameColumn, e);
+        }
+
+        private void inspectionView_CustomColumnDisplayText(object sender, CustomColumnDisplayTextEventArgs e)
+        {
+            if (e.Column.Name == controlTypeGridColumn.Name && e.Value != null)
+            {
+                PipeTestControlType result;
+                if (Enum.TryParse<PipeTestControlType>(e.Value.ToString(), out result))
+                {
+                    e.DisplayText = localizedPipeTestControlTypes[(int)result - 1]; //-1 because we skip 0
+                }
+            }
+            if (e.Column.Name == resultTypeGridColumn.Name && e.Value != null)
+            {
+                PipeTestResultType result;
+                if (Enum.TryParse<PipeTestResultType>(e.Value.ToString(), out result))
+                {
+                    e.DisplayText = localizedPipeTestResultTypes[(int)result - 1]; //-1 because we skip 0
+                }
+            }
+        }
+
+        private void jointOperationTypeLookUpEdit_CustomDisplayText(object sender, DevExpress.XtraEditors.Controls.CustomDisplayTextEventArgs e)
+        {
+            if (e.Value != null)
+            {
+                JointOperationType result;
+                if (Enum.TryParse<JointOperationType>(e.Value.ToString(), out result))
+                {
+                    e.DisplayText = localizedJointOperationTypes[(int)result - 1];
+                }
+            }
+        }
+
+        private void jointOperationTypeLookUpEdit_EditValueChanged(object sender, EventArgs e)
+        {
+            LookUpEdit lookup = sender as LookUpEdit;
+            if (lookup.ItemIndex != -1)
+            {
+                lookup.EditValue = (JointOperationType)lookup.ItemIndex + 1;
+            }
         }
 
     }

--- a/src/PrizmMainProject/Forms/Spool/SpoolsXtraForm.Designer.cs
+++ b/src/PrizmMainProject/Forms/Spool/SpoolsXtraForm.Designer.cs
@@ -28,7 +28,6 @@
         /// </summary>
         private void InitializeComponent()
         {
-            this.components = new System.ComponentModel.Container();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(SpoolsXtraForm));
             this.searchButton = new DevExpress.XtraEditors.SimpleButton();
             this.mainLayoutControl = new DevExpress.XtraLayout.LayoutControl();
@@ -67,8 +66,8 @@
             this.saveButtonLayout = new DevExpress.XtraLayout.LayoutControlItem();
             this.buttonsEmptySpace = new DevExpress.XtraLayout.EmptySpaceItem();
             this.deactivatedLayout = new DevExpress.XtraLayout.LayoutControlItem();
-            this.SpoolBindingSource = new System.Windows.Forms.BindingSource(this.components);
-            this.inspectorsDataSource = new System.Windows.Forms.BindingSource(this.components);
+            this.SpoolBindingSource = new System.Windows.Forms.BindingSource();
+            this.inspectorsDataSource = new System.Windows.Forms.BindingSource();
             ((System.ComponentModel.ISupportInitialize)(this.mainLayoutControl)).BeginInit();
             this.mainLayoutControl.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.deactivated.Properties)).BeginInit();
@@ -233,9 +232,6 @@
             this.resultLookUpEdit.AutoHeight = false;
             this.resultLookUpEdit.Buttons.AddRange(new DevExpress.XtraEditors.Controls.EditorButton[] {
             new DevExpress.XtraEditors.Controls.EditorButton(DevExpress.XtraEditors.Controls.ButtonPredefines.Combo)});
-            this.resultLookUpEdit.Columns.AddRange(new DevExpress.XtraEditors.Controls.LookUpColumnInfo[] {
-            new DevExpress.XtraEditors.Controls.LookUpColumnInfo("Value", "Status")});
-            this.resultLookUpEdit.DisplayMember = "Value";
             this.resultLookUpEdit.Name = "resultLookUpEdit";
             this.resultLookUpEdit.NullText = "";
             this.resultLookUpEdit.EditValueChanged += new System.EventHandler(this.resultLookUpEdit_EditValueChanged);

--- a/src/PrizmMainProject/Forms/Spool/SpoolsXtraForm.cs
+++ b/src/PrizmMainProject/Forms/Spool/SpoolsXtraForm.cs
@@ -29,11 +29,9 @@ namespace Prizm.Main.Forms.Spool
         private Guid id;
         private SpoolViewModel viewModel;
         private ExternalFilesXtraForm filesForm = null;
-        private Dictionary<PartInspectionStatus, string> inspectionStatusDict
-           = new Dictionary<PartInspectionStatus, string>();
         ICommandManager commandManager = new CommandManager();
         ISecurityContext ctx = Program.Kernel.Get<ISecurityContext>();
-
+        private List<string> localizedAllInspectionStatus = new List<string>();
         private InspectorSelectionControl inspectorSelectionControl = new InspectorSelectionControl();
 
         public bool IsMatchedByGuid(Guid id) { return this.id == id; }
@@ -99,13 +97,6 @@ namespace Prizm.Main.Forms.Spool
                 .Add(BindingHelper.CreateCheckEditInverseBinding(
                 "EditValue", SpoolBindingSource, "SpoolIsActive"));
 
-            inspectionStatusDict.Clear();
-            inspectionStatusDict.Add(PartInspectionStatus.Accepted, Program.LanguageManager.GetString(StringResources.PartInspectionStatus_Accepted));
-            inspectionStatusDict.Add(PartInspectionStatus.Hold, Program.LanguageManager.GetString(StringResources.PartInspectionStatus_Hold));
-            inspectionStatusDict.Add(PartInspectionStatus.Rejected, Program.LanguageManager.GetString(StringResources.PartInspectionStatus_Rejected));
-            inspectionStatusDict.Add(PartInspectionStatus.Pending, Program.LanguageManager.GetString(StringResources.PartInspectionStatus_Pending));
-            resultLookUpEdit.DataSource = inspectionStatusDict;
-
             inspectorsDataSource.DataSource = viewModel.Inspectors;
             inspectorsDataSource.ListChanged += (s, eve) => IsModified = true;
             inspectorSelectionControl.DataSource = inspectorsDataSource;
@@ -133,6 +124,10 @@ namespace Prizm.Main.Forms.Spool
 
         private void SpoolsXtraForm_Load(object sender, System.EventArgs e)
         {
+            foreach (var item in EnumWrapper<PartInspectionStatus>.EnumerateItems(skip0: true))
+            {
+                localizedAllInspectionStatus.Add(item.Item2);
+            }
             BindToViewModel();
 
             attachmentsButton.Enabled =
@@ -169,7 +164,14 @@ namespace Prizm.Main.Forms.Spool
                 new LocalizedItem(attachmentsButton, "Spool_AttachButton"),
                 new LocalizedItem(saveButton, "Spool_SaveButton"),
 
-                new LocalizedItem(deactivated, "Spool_DeactivatedCheckBox")
+                new LocalizedItem(deactivated, "Spool_DeactivatedCheckBox"),
+                new LocalizedItem(resultLookUpEdit, localizedAllInspectionStatus,new string []
+                                                                                      {
+                                                                                        StringResources.PartInspectionStatus_Pending.Id,
+                                                                                        StringResources.PartInspectionStatus_Hold.Id,
+                                                                                        StringResources.PartInspectionStatus_Rejected.Id,
+                                                                                        StringResources.PartInspectionStatus_Accepted.Id
+                                                                                      })
             };
         }
 
@@ -201,19 +203,21 @@ namespace Prizm.Main.Forms.Spool
         {
             LookUpEdit lookup = sender as LookUpEdit;
 
-            if(!(lookup.EditValue is PartInspectionStatus))
+            if (lookup.ItemIndex != -1)
             {
-                KeyValuePair<PartInspectionStatus, string> val
-                    = (KeyValuePair<PartInspectionStatus, string>)lookup.EditValue;
-                lookup.EditValue = val.Key;
+                lookup.EditValue = (PartInspectionStatus)lookup.ItemIndex + 1;
             }
         }
 
         private void resultLookUpEdit_CustomDisplayText(object sender, DevExpress.XtraEditors.Controls.CustomDisplayTextEventArgs e)
         {
-            if(e.Value is PartInspectionStatus)
+            if (e.Value != null)
             {
-                e.DisplayText = inspectionStatusDict[(PartInspectionStatus)e.Value];
+                PartInspectionStatus result;
+                if (Enum.TryParse<PartInspectionStatus>(e.Value.ToString(), out result))
+                {
+                    e.DisplayText = localizedAllInspectionStatus[(int)result - 1];
+                }
             }
         }
 

--- a/src/PrizmMainProject/Languages/LocalizedItem.cs
+++ b/src/PrizmMainProject/Languages/LocalizedItem.cs
@@ -1,4 +1,5 @@
-﻿using Prizm.Main.Forms.MainChildForm;
+﻿using DevExpress.XtraEditors;
+using Prizm.Main.Forms.MainChildForm;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -28,7 +29,8 @@ namespace Prizm.Main.Languages
             RadioGroup,
             TextEditOneWayStatus, 
             GridView,
-            FormHeader
+            FormHeader,
+            RepositoryCombo
         };
 
         public LocalizedItem(System.Windows.Forms.Control control, string resourceId)
@@ -218,6 +220,23 @@ namespace Prizm.Main.Languages
             }
         }
 
+        public LocalizedItem(DevExpress.XtraEditors.Repository.RepositoryItemComboBox repositoryCombo, string[] resourceIds)
+        {
+            this.resourceIds = new string[resourceIds.Length];
+            for (int index = 0; index < resourceIds.Length; index++)
+            {
+                this.resourceIds[index] = resourceIds[index];
+            }
+            this.obj = (object)repositoryCombo;
+            this.type = ItemType.RepositoryCombo;
+            this.defaultValues = new string[resourceIds.Length];
+
+            for (int index = 0; index < resourceIds.Length; index++)
+            {
+                this.defaultValues[index] = repositoryCombo.Items[index].ToString();
+            }
+        }
+
         public string Text
         {
             set
@@ -323,7 +342,17 @@ namespace Prizm.Main.Languages
                                 }
                             }
                             break;
+                        case ItemType.RepositoryCombo:
+                            {
+                                var repoCombo = (DevExpress.XtraEditors.Repository.RepositoryItemComboBox)obj;
+                        //set selected index somehow
+                                if (index < Count)
+                                {
+                                    ((DevExpress.XtraEditors.Repository.RepositoryItemComboBox)obj).Items[index] = value;
+                                }
 
+                            }
+                            break;
                         default:
                             break;
                     }
@@ -407,6 +436,10 @@ namespace Prizm.Main.Languages
                     break;
                 case ItemType.FormHeader:
                     ((Tuple<PrizmForm, List<string>>)obj).Item1.UpdateTitle();
+                    break;
+                case ItemType.RepositoryCombo:
+                    var repoCombo = (DevExpress.XtraEditors.Repository.RepositoryItemComboBox)obj;
+//set selected index
                     break;
                 default:
                     break;

--- a/src/PrizmMainProject/Languages/LocalizedItem.cs
+++ b/src/PrizmMainProject/Languages/LocalizedItem.cs
@@ -29,7 +29,8 @@ namespace Prizm.Main.Languages
             TextEditOneWayStatus, 
             GridView,
             FormHeader,
-            RepositoryLookupEdit
+            RepositoryLookupEdit,
+            CheckedListBox
         };
 
         public LocalizedItem(System.Windows.Forms.Control control, string resourceId)
@@ -236,6 +237,22 @@ namespace Prizm.Main.Languages
             }
         }
 
+        public LocalizedItem(DevExpress.XtraEditors.CheckedListBoxControl checkedListBox, string[] resourceIds)
+        {
+            this.resourceIds = new string[resourceIds.Length];
+            for (int index = 0; index < resourceIds.Length; index++)
+            {
+                this.resourceIds[index] = resourceIds[index];
+            }
+            this.obj = (object)checkedListBox;
+            this.type = ItemType.CheckedListBox;
+            this.defaultValues = new string[resourceIds.Length];
+            for (int index = 0; index < resourceIds.Length; index++)
+            {
+                this.defaultValues[index] = (string)checkedListBox.Items[index].Description;
+            }
+        }
+
         public string Text
         {
             set
@@ -341,6 +358,7 @@ namespace Prizm.Main.Languages
                                 }
                             }
                             break;
+
                         case ItemType.RepositoryLookupEdit:
                             {
                                 var list = ((Tuple<DevExpress.XtraEditors.Repository.RepositoryItemLookUpEdit, List<string>>)obj).Item2;
@@ -349,10 +367,14 @@ namespace Prizm.Main.Languages
                                     list[index] = value;
                                 }
                                 ((Tuple<DevExpress.XtraEditors.Repository.RepositoryItemLookUpEdit, List<string>>)obj).Item1.DataSource = list;
-
                             }
                             break;
 
+                        case ItemType.CheckedListBox:
+                            {
+                                ((DevExpress.XtraEditors.CheckedListBoxControl)obj).Items[index].Description = value;
+                            }
+                            break;
                         default:
                             break;
                     }
@@ -436,6 +458,9 @@ namespace Prizm.Main.Languages
                     break;
                 case ItemType.FormHeader:
                     ((Tuple<PrizmForm, List<string>>)obj).Item1.UpdateTitle();
+                    break;
+                case ItemType.CheckedListBox:
+                    ((DevExpress.XtraEditors.CheckedListBoxControl)obj).Refresh();
                     break;
                 default:
                     break;

--- a/src/PrizmMainProject/Languages/LocalizedItem.cs
+++ b/src/PrizmMainProject/Languages/LocalizedItem.cs
@@ -28,7 +28,8 @@ namespace Prizm.Main.Languages
             RadioGroup,
             TextEditOneWayStatus, 
             GridView,
-            FormHeader
+            FormHeader,
+            RepositoryLookupEdit
         };
 
         public LocalizedItem(System.Windows.Forms.Control control, string resourceId)
@@ -218,6 +219,23 @@ namespace Prizm.Main.Languages
             }
         }
 
+        public LocalizedItem(DevExpress.XtraEditors.Repository.RepositoryItemLookUpEdit repoLookup,  List<string> list, string[] resourceIds)
+        {
+        this.resourceIds = new string[resourceIds.Length];
+            for (int index = 0; index < resourceIds.Length; index++)
+            {
+                this.resourceIds[index] = resourceIds[index];
+            }
+            this.obj = (object)new Tuple<DevExpress.XtraEditors.Repository.RepositoryItemLookUpEdit, List<string>>(repoLookup, list);
+            this.type = ItemType.RepositoryLookupEdit;
+            this.defaultValues = new string[resourceIds.Length];
+
+            for (int index = 0; index < resourceIds.Length; index++)
+            {
+                this.defaultValues[index] = list[index];
+            }
+        }
+
         public string Text
         {
             set
@@ -321,6 +339,17 @@ namespace Prizm.Main.Languages
                                 {
                                     list[index] = value;
                                 }
+                            }
+                            break;
+                        case ItemType.RepositoryLookupEdit:
+                            {
+                                var list = ((Tuple<DevExpress.XtraEditors.Repository.RepositoryItemLookUpEdit, List<string>>)obj).Item2;
+                                if (index < list.Count)
+                                {
+                                    list[index] = value;
+                                }
+                                ((Tuple<DevExpress.XtraEditors.Repository.RepositoryItemLookUpEdit, List<string>>)obj).Item1.DataSource = list;
+
                             }
                             break;
 

--- a/src/PrizmMainProject/Languages/LocalizedItem.cs
+++ b/src/PrizmMainProject/Languages/LocalizedItem.cs
@@ -1,5 +1,4 @@
-﻿using DevExpress.XtraEditors;
-using Prizm.Main.Forms.MainChildForm;
+﻿using Prizm.Main.Forms.MainChildForm;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -29,8 +28,7 @@ namespace Prizm.Main.Languages
             RadioGroup,
             TextEditOneWayStatus, 
             GridView,
-            FormHeader,
-            RepositoryCombo
+            FormHeader
         };
 
         public LocalizedItem(System.Windows.Forms.Control control, string resourceId)
@@ -220,23 +218,6 @@ namespace Prizm.Main.Languages
             }
         }
 
-        public LocalizedItem(DevExpress.XtraEditors.Repository.RepositoryItemComboBox repositoryCombo, string[] resourceIds)
-        {
-            this.resourceIds = new string[resourceIds.Length];
-            for (int index = 0; index < resourceIds.Length; index++)
-            {
-                this.resourceIds[index] = resourceIds[index];
-            }
-            this.obj = (object)repositoryCombo;
-            this.type = ItemType.RepositoryCombo;
-            this.defaultValues = new string[resourceIds.Length];
-
-            for (int index = 0; index < resourceIds.Length; index++)
-            {
-                this.defaultValues[index] = repositoryCombo.Items[index].ToString();
-            }
-        }
-
         public string Text
         {
             set
@@ -342,17 +323,7 @@ namespace Prizm.Main.Languages
                                 }
                             }
                             break;
-                        case ItemType.RepositoryCombo:
-                            {
-                                var repoCombo = (DevExpress.XtraEditors.Repository.RepositoryItemComboBox)obj;
-                        //set selected index somehow
-                                if (index < Count)
-                                {
-                                    ((DevExpress.XtraEditors.Repository.RepositoryItemComboBox)obj).Items[index] = value;
-                                }
 
-                            }
-                            break;
                         default:
                             break;
                     }
@@ -436,10 +407,6 @@ namespace Prizm.Main.Languages
                     break;
                 case ItemType.FormHeader:
                     ((Tuple<PrizmForm, List<string>>)obj).Item1.UpdateTitle();
-                    break;
-                case ItemType.RepositoryCombo:
-                    var repoCombo = (DevExpress.XtraEditors.Repository.RepositoryItemComboBox)obj;
-//set selected index
                     break;
                 default:
                     break;

--- a/src/PrizmMainProject/Languages/StringResources.cs
+++ b/src/PrizmMainProject/Languages/StringResources.cs
@@ -1174,6 +1174,29 @@ namespace Prizm.Main.Languages
             Description = "Настройки - Трубопровод. Активность операции"
         };
 
+        public static StringResource JointOperationType_Test = new StringResource
+        {
+            Id = "JointOperationType_Test",
+            Description = "Настройки - Трубопровод.Тип операции.Контрольная"
+        };
+
+        public static StringResource JointOperationType_Action = new StringResource
+        {
+            Id = "JointOperationType_Action",
+            Description = "Настройки - Трубопровод.Тип операции.Ремонтная"
+        };
+
+        public static StringResource JointOperationType_Weld = new StringResource
+        {
+            Id = "JointOperationType_Weld",
+            Description = "Настройки - Трубопровод.Тип операции.Сварка"
+        };
+
+        public static StringResource JointOperationType_Withdraw = new StringResource
+        {
+            Id = "JointOperationType_Withdraw",
+            Description = "Настройки - Трубопровод.Тип операции.Вырезка стыка"
+        };
         //component page
 
         public static StringResource SettingsComponent_PartsType = new StringResource

--- a/src/PrizmMainProject/Properties/Resources.Designer.cs
+++ b/src/PrizmMainProject/Properties/Resources.Designer.cs
@@ -810,6 +810,42 @@ namespace Prizm.Main.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Ремонтная.
+        /// </summary>
+        internal static string JointOperationType_Action {
+            get {
+                return ResourceManager.GetString("JointOperationType_Action", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Контрольная.
+        /// </summary>
+        internal static string JointOperationType_Test {
+            get {
+                return ResourceManager.GetString("JointOperationType_Test", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Сварка.
+        /// </summary>
+        internal static string JointOperationType_Weld {
+            get {
+                return ResourceManager.GetString("JointOperationType_Weld", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Вырезка стыка.
+        /// </summary>
+        internal static string JointOperationType_Withdraw {
+            get {
+                return ResourceManager.GetString("JointOperationType_Withdraw", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Активные.
         /// </summary>
         internal static string JointSearch_ActivityCriteria_StatusActive {

--- a/src/PrizmMainProject/Properties/Resources.resx
+++ b/src/PrizmMainProject/Properties/Resources.resx
@@ -1102,4 +1102,16 @@
   <data name="SelectWeldersForOperationHeader" xml:space="preserve">
     <value>Ошибка создания сварочной операции</value>
   </data>
+  <data name="JointOperationType_Action" xml:space="preserve">
+    <value>Ремонтная</value>
+  </data>
+  <data name="JointOperationType_Test" xml:space="preserve">
+    <value>Контрольная</value>
+  </data>
+  <data name="JointOperationType_Weld" xml:space="preserve">
+    <value>Сварка</value>
+  </data>
+  <data name="JointOperationType_Withdraw" xml:space="preserve">
+    <value>Вырезка стыка</value>
+  </data>
 </root>


### PR DESCRIPTION
Issue: Not all field names are localized #1163
Items:
mill pipe, inspection operations, operation status seems
Pipeline/operation type in grid seems to be enum name
pipeline elements search: type in grid is taken from Enum
see type of entity at incoming inspection, window of choosing element
status in grid at search joints seems to be taken from enum
