### PR TITLE
add IsEditorActive check before refresh property value

### DIFF
--- a/src/PrizmMainProject/Forms/PipeMill/NewEdit/MillPipeNewEditXtraForm.cs
+++ b/src/PrizmMainProject/Forms/PipeMill/NewEdit/MillPipeNewEditXtraForm.cs
@@ -834,7 +834,10 @@ namespace Prizm.Main.Forms.PipeMill.NewEdit
 
         private void plateNumber_EditValueChanged(object sender, EventArgs e)
         {
-            viewModel.PlateNumber = plateNumber.Text;
+            if (plateNumber.IsEditorActive)
+            {
+                viewModel.PlateNumber = plateNumber.Text;
+            }
             commandManager.RefreshVisualState();
         }
 


### PR DESCRIPTION
Problems investigation by DB from Client #1247

part:
b. если выбрать Continue и ввести все 3 результата в состояние Passed и соответствующие результаты в нужных полях – деактивируются кнопки Сохранить и Сохранить/Создать (Prism 2.png)

and

"wrong validation for plate number for opening existing pipe #1162"
