### PR TITLE
Exception while adding second attachment 

### DIFF
--- a/src/PrizmMainProject/App.config
+++ b/src/PrizmMainProject/App.config
@@ -12,7 +12,7 @@
   </startup>
 
   <connectionStrings>
-    <add name="PrizmDatabase" connectionString="Data Source=(LocalDb)\v11.0;Initial Catalog=prizm;Integrated Security=true" />
+    <add name="PrizmDatabase" connectionString="Data Source=(LocalDb)\v11.0;Initial Catalog=prism;Integrated Security=true" />
   </connectionStrings>
 
   <appSettings>

--- a/src/PrizmMainProject/Forms/Component/NewEdit/ComponentNewEditXtraForm.cs
+++ b/src/PrizmMainProject/Forms/Component/NewEdit/ComponentNewEditXtraForm.cs
@@ -114,8 +114,8 @@ namespace Prizm.Main.Forms.Component.NewEdit
             {
                 filesForm = new ExternalFilesXtraForm();
                 viewModel.FilesFormViewModel = filesForm.ViewModel;
-                viewModel.FilesFormViewModel.RefreshFiles(viewModel.Component.Id);
             }
+            viewModel.FilesFormViewModel.RefreshFiles(viewModel.Component.Id);
             filesForm.SetData(IsEditMode);
             filesForm.ShowDialog();
             

--- a/src/PrizmMainProject/Forms/ExternalFile/AddExternalFileCommand.cs
+++ b/src/PrizmMainProject/Forms/ExternalFile/AddExternalFileCommand.cs
@@ -64,6 +64,8 @@ namespace Prizm.Main.Forms.ExternalFile
                             fileEntity.FileName,
                             fileEntity.Id));
                     }
+                    viewModel.FilesToAttach.Clear();
+                    viewModel.RefreshFiles(viewModel.Item);
                 }
                 catch (RepositoryException ex)
                 {

--- a/src/PrizmMainProject/Forms/ExternalFile/ExternalFilesViewModel.cs
+++ b/src/PrizmMainProject/Forms/ExternalFile/ExternalFilesViewModel.cs
@@ -183,7 +183,7 @@ namespace Prizm.Main.Forms.ExternalFile
                 };
                 repos.FileRepo.Save(fileEntity);
             }
-
+            FilesToAttach.Clear();
             notify.ShowNotify(Program.LanguageManager.GetString(StringResources.ExternalFiles_FileAttachSuccess),
                 Program.LanguageManager.GetString(StringResources.ExternalFiles_FileAttachSuccessHeader));
         }

--- a/src/PrizmMainProject/Properties/Resources.Designer.cs
+++ b/src/PrizmMainProject/Properties/Resources.Designer.cs
@@ -508,6 +508,60 @@ namespace Prizm.Main.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Вложения успешно добавлены.
+        /// </summary>
+        internal static string ExternalFiles_FileAttachSuccess {
+            get {
+                return ResourceManager.GetString("ExternalFiles_FileAttachSuccess", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Добавление вложений.
+        /// </summary>
+        internal static string ExternalFiles_FileAttachSuccessHeader {
+            get {
+                return ResourceManager.GetString("ExternalFiles_FileAttachSuccessHeader", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Загрузка файла.
+        /// </summary>
+        internal static string ExternalFiles_FileDownloadHeader {
+            get {
+                return ResourceManager.GetString("ExternalFiles_FileDownloadHeader", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Файл успешно загружен.
+        /// </summary>
+        internal static string ExternalFiles_FileDownloadSuccess {
+            get {
+                return ResourceManager.GetString("ExternalFiles_FileDownloadSuccess", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Для просмотра и скачивания вложений необходимо их предварительное сохранение.
+        /// </summary>
+        internal static string ExternalFiles_FileViewDownloadFail {
+            get {
+                return ResourceManager.GetString("ExternalFiles_FileViewDownloadFail", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Просмотр и загрузка несохрaненных файлов.
+        /// </summary>
+        internal static string ExternalFiles_FileViewDownloadFailHeader {
+            get {
+                return ResourceManager.GetString("ExternalFiles_FileViewDownloadFailHeader", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Результаты измерения длины должны быть введены..
         /// </summary>
         internal static string FixedCategoryLengthPassed {

--- a/src/PrizmMainProject/Properties/Resources.resx
+++ b/src/PrizmMainProject/Properties/Resources.resx
@@ -1123,4 +1123,22 @@
   <data name="FixedCategoryLengthPassedHeader" xml:space="preserve">
     <value>Не заданы результаты измерений</value>
   </data>
+  <data name="ExternalFiles_FileAttachSuccess" xml:space="preserve">
+    <value>Вложения успешно добавлены</value>
+  </data>
+  <data name="ExternalFiles_FileAttachSuccessHeader" xml:space="preserve">
+    <value>Добавление вложений</value>
+  </data>
+  <data name="ExternalFiles_FileDownloadHeader" xml:space="preserve">
+    <value>Загрузка файла</value>
+  </data>
+  <data name="ExternalFiles_FileDownloadSuccess" xml:space="preserve">
+    <value>Файл успешно загружен</value>
+  </data>
+  <data name="ExternalFiles_FileViewDownloadFail" xml:space="preserve">
+    <value>Для просмотра и скачивания вложений необходимо их предварительное сохранение</value>
+  </data>
+  <data name="ExternalFiles_FileViewDownloadFailHeader" xml:space="preserve">
+    <value>Просмотр и загрузка несохрaненных файлов</value>
+  </data>
 </root>


### PR DESCRIPTION
Added clearing of files to attachment queue. 
Added files refreshing so that they can be viewed after saving. 
Done for both types of saving (using command and in one transaction)
Also added missing translations of messages. 
Changed prizm to prism in App.config to make debugging easier.
Issue: Exception while adding second attachment #1290 
problem was introduced by Saving files should be one transaction with saving the entity #854
