### PR TITLE
Changed description of string resource

### DIFF
--- a/install/Lang/Translations/Strings.en-US.txt
+++ b/install/Lang/Translations/Strings.en-US.txt
@@ -2026,7 +2026,7 @@ ExternalFiles_NotCopied_Header=External files saving error
 ;Прикрепленные файлы не сохранены
 ExternalFiles_NotCopied=Attached files weren't saved
 
-;Размер вложения больше разрешенного
+;Сообщение: Размер вложения больше разрешенного
 ExternalFiles_FileSizeIsTooBig=Attaching file's size is bigger than allowed
 
 ;Тип рабочей станции. Неопределен

--- a/src/PrizmMainProject/Languages/StringResources.cs
+++ b/src/PrizmMainProject/Languages/StringResources.cs
@@ -349,7 +349,7 @@ namespace Prizm.Main.Languages
         public static StringResource ExternalFiles_FileSizeIsTooBig= new StringResource
         {
             Id = "ExternalFiles_FileSizeIsTooBig",
-            Description = "Размер вложения больше разрешенного"
+            Description = "Сообщение: Размер вложения больше разрешенного"
         };
 
 


### PR DESCRIPTION
"Размер вложения больше разрешенного"
was replaced by "Сообщение: Размер вложения больше разрешенного"
Issue: On Adding External File, check max file size #1299
