### PR TITLE
 Fix "When you open a "Стык" it is always marked as changed"

### DIFF
--- a/src/PrizmMainProject/Forms/Joint/NewEdit/JointNewEditXtraForm.cs
+++ b/src/PrizmMainProject/Forms/Joint/NewEdit/JointNewEditXtraForm.cs
@@ -201,7 +201,13 @@ namespace Prizm.Main.Forms.Joint.NewEdit
             }
             BindCommands();
             BindToViewModel();
-            viewModel.PropertyChanged += (s, eve) => IsModified = true;
+            viewModel.PropertyChanged += (s, eve) => 
+                {
+                    if ( eve.PropertyName != "Pieces")
+                    {
+                        IsModified = true;
+                    }
+                };
             IsEditMode = viewModel.JointIsActive;
             IsModified = false;
 


### PR DESCRIPTION
Add  exclusion for property  "Pieces"
on event PropertyChanged
#1113
