### PR TITLE
Crash at exit when Modified is on #1352

### DIFF
--- a/src/PrizmMainProject/Forms/MainChildForm/PrizmApplicationXtraForm.cs
+++ b/src/PrizmMainProject/Forms/MainChildForm/PrizmApplicationXtraForm.cs
@@ -396,7 +396,8 @@ namespace Prizm.Main.Forms.MainChildForm
 
         private void barButtonItemExit_ItemClick(object sender, ItemClickEventArgs e)
         {
-            Application.Exit();
+            this.Close(); //Application.Exit() causes  iteration the Application.OpenForms collection which is modified 
+                          //similar problem: http://stackoverflow.com/questions/1312885/application-exit-vs-application-exitthread-vs-environment-exit
         }
 
         public void UpdateStatusBar(string text)


### PR DESCRIPTION
Changed Application.Exit() on this.Close() to avoid exception
Issue: Crash at exit when Modified is on #1352
