### PR TITLE
Import can be done only if file path is not empty

### DIFF
--- a/src/PrizmMainProject/Forms/Synch/ImportForm.Designer.cs
+++ b/src/PrizmMainProject/Forms/Synch/ImportForm.Designer.cs
@@ -51,6 +51,7 @@
             // 
             this.txtArchive.Location = new System.Drawing.Point(60, 26);
             this.txtArchive.Name = "txtArchive";
+            this.txtArchive.Properties.ReadOnly = true;
             this.txtArchive.Size = new System.Drawing.Size(476, 20);
             this.txtArchive.TabIndex = 1;
             // 

--- a/src/PrizmMainProject/Forms/Synch/ImportForm.cs
+++ b/src/PrizmMainProject/Forms/Synch/ImportForm.cs
@@ -161,8 +161,11 @@ namespace Prizm.Main.Forms.Synch
 
       private void btnImport_Click(object sender, EventArgs e)
       {
-         EnableImportButton(false);
-         new Task(() => importer.Import(txtArchive.Text)).Start();
+          if (txtArchive.Text != string.Empty)
+          {
+              EnableImportButton(false);
+              new Task(() => importer.Import(txtArchive.Text)).Start();
+          }
       }
 
       private void ImportForm_FormClosing(object sender, FormClosingEventArgs e)


### PR DESCRIPTION
Import can be done only if file path is not empty.
Also made file path field read-only so that only existing path can be
entered
Issue: Deactivated button on import #1448
