### PR TITLE
fix AuditInterceptor memory leak with evict record

### DIFF
--- a/src/Data/DAL/Hibernate/AuditInterceptor.cs
+++ b/src/Data/DAL/Hibernate/AuditInterceptor.cs
@@ -110,6 +110,7 @@ namespace Prizm.Data.DAL.Hibernate
             LogRepo.BeginTransaction();
             LogRepo.Save(record);
             LogRepo.Commit();
+            LogRepo.Evict(record);
         }
 
         /// <summary>


### PR DESCRIPTION
За ночь период зависания составил 25-30 секунд и общее время процессора для процесса Prism #1496
