### PR TITLE
Added logic of changing users language while setup #PRISM-2 Fixed

### DIFF
--- a/install/prizm_demo_installer_script.iss
+++ b/install/prizm_demo_installer_script.iss
@@ -366,7 +366,7 @@ end;
 
 function SetUsersLanguage(): String;
 begin
-if ActiveLanguage='russian' then Result:='ru-Ru' else Result:='en-Us';
+if ActiveLanguage='russian' then Result:='ru-RU' else Result:='en-US';
 end;
 
 function ValidateProjectName(name : String) : Boolean;

--- a/install/prizm_demo_installer_script.iss
+++ b/install/prizm_demo_installer_script.iss
@@ -364,6 +364,11 @@ begin
     Result := GetUpdateProductName()
 end;
 
+function SetUsersLanguage(): String;
+begin
+if ActiveLanguage='russian' then Result:='ru-Ru' else Result:='en-Us';
+end;
+
 function ValidateProjectName(name : String) : Boolean;
 var n : Integer;
     b : String;
@@ -753,7 +758,7 @@ end;
 procedure UpdateConfig();
 var
   XMLDoc, RootNode, Nodes, Node: Variant;
-  ConfigFilename, Key: String;
+  ConfigFilename, Key: String; 
   i: integer;
 
 begin
@@ -789,8 +794,23 @@ begin
         'PrismDatabase' : Node.setAttribute('connectionString', 'Data Source=(LocalDb)\v11.0;Initial Catalog=' + GetProjectName('') + ';Integrated Security=true;AttachDBFileName=' + ExpandConstant('{app}') + '\Data\' + GetProjectName('') + '.mdf');
       end;
     end;
-  end;
-
+  end;  
+  
+  //update user settings
+  Nodes := RootNode.selectNodes('//configuration/userSettings/Prizm.Main.Properties.Settings/setting');
+  
+  for i := 0 to Nodes.length - 1 do
+  begin
+    Node := Nodes.Item[i];
+    if Node.NodeType = 1 then 
+	begin
+		key := Node.getAttribute('name');
+		Case key of	  
+		'UsersLanguage' : Node.childNodes[0].text := SetUsersLanguage();	   
+	    end;
+	end;
+  end; 
+	
 
   if IsNewInstall then
   begin
@@ -813,7 +833,7 @@ begin
       end;
     end;
   end;
-
+  
   XMLDoc.Save(ConfigFilename); 
 
 end;

--- a/src/PrizmMainProject/App.config
+++ b/src/PrizmMainProject/App.config
@@ -49,7 +49,7 @@
   <userSettings>
     <Prizm.Main.Properties.Settings>
       <setting name="UsersLanguage" serializeAs="String">
-        <value>ru-Ru</value>
+        <value>ru-RU</value>
       </setting>
     </Prizm.Main.Properties.Settings>
   </userSettings>

--- a/src/PrizmMainProject/Forms/MainChildForm/FirstSetupForm/FirstSetupXtraForm.cs
+++ b/src/PrizmMainProject/Forms/MainChildForm/FirstSetupForm/FirstSetupXtraForm.cs
@@ -31,8 +31,7 @@ namespace Prizm.Main.Forms.MainChildForm.FirstSetupForm
         {
             InitializeComponent();
             SetControlsTextLength();
-            viewModel = vm;
-            this.Text += ": [" + viewModel.Type + "]";
+            viewModel = vm;          
 
             this.AcceptButton = saveButton;
             this.CancelButton = cancelButton;
@@ -46,6 +45,12 @@ namespace Prizm.Main.Forms.MainChildForm.FirstSetupForm
             }
             BindToViewModel();
             pipeNumberMaskRulesLabel.Text = Program.LanguageManager.GetString(StringResources.Mask_Label);
+            localizedHeader.Clear();
+
+            localizedHeader.Add(Resources.FirstSetup_FormHeader);  // usage of Resources is OK - setting default values here
+            localizedHeader.Add(WorkstationType.Mill.ToString());
+            localizedHeader.Add(WorkstationType.Master.ToString());
+            localizedHeader.Add(WorkstationType.Construction.ToString());
         }
 
         private void BindToViewModel()
@@ -79,6 +84,7 @@ namespace Prizm.Main.Forms.MainChildForm.FirstSetupForm
                 new LocalizedItem(titleLayoutControl, StringResources.FirstSetup_ProjectTitleLabel.Id),
                 new LocalizedItem(fileLayoutControlItem, StringResources.FirstSetup_FileSizeLabel.Id),
                 new LocalizedItem(typeLayoutControlItem, StringResources.FirstSetup_TypeLabel.Id),
+                new LocalizedItem(maskLayoutControlItem, StringResources.FirstSetup_PipeNumberFormatLabel.Id),
                 new LocalizedItem(millLayoutControlItem, StringResources.FirstSetup_MillLabel.Id),
                 new LocalizedItem(loginLayoutControlItem, StringResources.FirstSetup_LoginLabel.Id),
                 new LocalizedItem(passLayoutControlItem, StringResources.FirstSetup_PasswordLabel.Id),
@@ -86,7 +92,10 @@ namespace Prizm.Main.Forms.MainChildForm.FirstSetupForm
                 new LocalizedItem(reEnterLayoutControlItem, StringResources.FirstSetup_ReEnterPasswordLabel.Id),
                 new LocalizedItem(lastNameLayoutControlItem, StringResources.FirstSetup_LastNameLabel.Id),
                 new LocalizedItem(firstNameLayoutControlItem, StringResources.FirstSetup_FirstNameLabel.Id),
+                new LocalizedItem(middleNameLayoutControlItem, StringResources.FirstSetup_MiddleNameLabel.Id),
                 new LocalizedItem(millLayoutControlItem, StringResources.FirstSetup_MiddleNameLabel.Id),
+                new LocalizedItem(projectLayoutGroup,StringResources.FirstSetup_ProjectGroup.Id),
+                new LocalizedItem(adminLayoutControlGroup, StringResources.FirstSetup_MainAdministratorGroup.Id),
                 
                 new LocalizedItem(saveButton, StringResources.FirstSetup_SaveButton.Id),
                 new LocalizedItem(cancelButton, StringResources.FirstSetup_CancelButton.Id),
@@ -96,8 +105,27 @@ namespace Prizm.Main.Forms.MainChildForm.FirstSetupForm
                             StringResources.WorkstationType_Master.Id, 
                             StringResources.WorkstationType_Mill.Id, 
                             StringResources.WorkstationType_Construction.Id} ),
-            };
+
+                               // header
+                new LocalizedItem(this, localizedHeader, new string[] { "FirstSetup_FormHeader", 
+                    "MainWindowHeader_Mill", "MainWindowHeader_Master", "MainWindowHeader_Construction" } ),
+           };
         }
+               public override void UpdateTitle()
+        {
+            // base.UpdateTitle(); should not be called
+            this.Text = string.Concat(localizedHeader[0], " [", 
+                viewModel.Project.WorkstationType == WorkstationType.Mill 
+                ? localizedHeader[1]
+                : viewModel.Project.WorkstationType == WorkstationType.Master
+                    ? localizedHeader[2]
+                    : viewModel.Project.WorkstationType == WorkstationType.Construction
+                        ? localizedHeader[3]
+                        : ""
+            , "]");
+        }
+           
+        
 
         #endregion // --- Localization ---
 

--- a/src/PrizmMainProject/Languages/LocalizedStrings/Strings.en-US.txt
+++ b/src/PrizmMainProject/Languages/LocalizedStrings/Strings.en-US.txt
@@ -1978,6 +1978,9 @@ FirstSetup_TypeLabel=Workstation type
 ;Начальные установки. Название завода
 FirstSetup_MillLabel=Mill name
 
+;Начальные установки. Формат номера трубы
+FirstSetup_PipeNumberFormatLabel=Pipe number format
+
 ;Начальные установки. Логин
 FirstSetup_LoginLabel=Login
 
@@ -1995,6 +1998,15 @@ FirstSetup_FirstNameLabel=First name
 
 ;Начальные установки. Отчество
 FirstSetup_MiddleNameLabel=Middle name 
+
+;Начальные установки.Надпись группы проекта
+FirstSetup_ProjectGroup=Project
+
+;Начальные установки.Надпись главного администратора
+FirstSetup_MainAdministratorGroup = Main administrator
+
+;Начальные установки.Надпись окна: первичные настройки
+FirstSetup_FormHeader= First setup
 
 ;Начальные установки. Кнопка сохранить
 FirstSetup_SaveButton=&Save

--- a/src/PrizmMainProject/Languages/StringResources.cs
+++ b/src/PrizmMainProject/Languages/StringResources.cs
@@ -4430,9 +4430,28 @@ namespace Prizm.Main.Languages
             Id = "FirstSetup_CancelButton",
             Description = "Начальные установки. Кнопка отмена"
         };
+        public static StringResource FirstSetup_PipeNumberFormatLabel = new StringResource
+        {
+            Id = "FirstSetup_PipeNumberFormatLabel",
+            Description = "Начальные установки. Формат номера трубы"
+        };
+        public static StringResource FirstSetup_ProjectGroup = new StringResource
+        {
+            Id = "FirstSetup_ProjectGroup",
+            Description = "Начальные установки.Надпись группы проекта"
+        };
 
+        public static StringResource FirstSetup_MainAdministratorGroup = new StringResource
+        {
+            Id = "FirstSetup_MainAdministratorGroup",
+            Description = "Начальные установки.Надпись главного администратора"
+        };
 
-
+        public static StringResource FirstSetup_FormHeader = new StringResource
+        {
+            Id = "FirstSetup_FormHeader",
+            Description = "Начальные установки.Надпись окна: первичные настройки"
+        };
         #endregion
 
         #region Heat

--- a/src/PrizmMainProject/Properties/Resources.Designer.cs
+++ b/src/PrizmMainProject/Properties/Resources.Designer.cs
@@ -706,6 +706,15 @@ namespace Prizm.Main.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Первичные настройки.
+        /// </summary>
+        internal static string FirstSetup_FormHeader {
+            get {
+                return ResourceManager.GetString("FirstSetup_FormHeader", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Результаты измерения длины должны быть введены..
         /// </summary>
         internal static string FixedCategoryLengthPassed {

--- a/src/PrizmMainProject/Properties/Resources.resx
+++ b/src/PrizmMainProject/Properties/Resources.resx
@@ -1367,10 +1367,10 @@
   <data name="ReleaseNoteNewEdit_DifferentTypeSizeInRailcarExtended" xml:space="preserve">
     <value>В вагоне</value>
   </data>
-<data name="Import_Progress_Message_Counter" xml:space="preserve">
+  <data name="Import_Progress_Message_Counter" xml:space="preserve">
     <value>Импортируется элемент</value>
   </data>
-<data name="Import_Progress_Message_Type" xml:space="preserve">
+  <data name="Import_Progress_Message_Type" xml:space="preserve">
     <value>Тип элемента:</value>
   </data>
   <data name="MissingPortionsDialog_PortionsAlreadyExist" xml:space="preserve">
@@ -1390,5 +1390,8 @@
   </data>
   <data name="PurchaseOrder_ValueRequired" xml:space="preserve">
     <value>Введите номер наряд-заказа</value>
+  </data>
+  <data name="FirstSetup_FormHeader" xml:space="preserve">
+    <value>Первичные настройки</value>
   </data>
 </root>


### PR DESCRIPTION
Added logic of changing users language (in config file) while setup
Issue :
# PRISM-2 Нужно сделать, чтобы язык первичной настройки PRISM

соответствовал языку, выбранному в установщике
