### PR TITLE
Assigned IsEditMode true to make it work #PRISM-26 Fixed

### DIFF
--- a/src/PrizmMainProject/Forms/Settings/SettingsXtraForm.cs
+++ b/src/PrizmMainProject/Forms/Settings/SettingsXtraForm.cs
@@ -142,6 +142,7 @@ namespace Prizm.Main.Forms.Settings
             SetWorkstationReadonlyFields();
             UpdateSeamTypesComboBox();
             ISecurityContext ctx = Program.Kernel.Get<ISecurityContext>();
+            IsEditMode = true;//do not remove until IsEditMode logic is changed
             IsEditMode = ctx.HasAccess(global::Domain.Entity.Security.Privileges.EditSettings);
 
             repositoryWelderCertDateEdit.SetLimits();


### PR DESCRIPTION
Assigned IsEditMode true to make it work
Issue:
# PRISM-26 Settings forms give you visibility of changing settings when

you are not allowed to. #1645
