### PR TITLE
add nullReference check #PRISM-30 Fixed

### DIFF
--- a/src/PrizmMainProject/Forms/PipeMill/NewEdit/MillPipeNewEditXtraForm.cs
+++ b/src/PrizmMainProject/Forms/PipeMill/NewEdit/MillPipeNewEditXtraForm.cs
@@ -579,7 +579,7 @@ namespace Prizm.Main.Forms.PipeMill.NewEdit
             LookUpEdit q = sender as LookUpEdit;
             object row = q.Properties.GetDataSourceRowByKeyValue(q.EditValue);
             PipeTest selectedTest = q.Properties.GetDataSourceRowByKeyValue(q.EditValue) as PipeTest;
-            if(selectedTest != null)
+            if (selectedTest != null && currentTestResult != null)
                 currentTestResult.Operation = selectedTest;
         }
 


### PR DESCRIPTION
PRISM-30 Using custom auto filter at inspection operations grid leads to crash
