### PR TITLE
Increased project title length  #PRISM-35 Fixed

### DIFF
--- a/install/prizm_demo_installer_script.iss
+++ b/install/prizm_demo_installer_script.iss
@@ -530,6 +530,7 @@ begin
 
   NewProductName := TNewEdit.Create(NewProductPage);
   NewProductName.Top := StaticText1.Top + StaticText1.Height + ScaleY(1);
+  NewProductName.MaxLength :=50;
   NewProductName.Width := NewProductPage.SurfaceWidth;
   NewProductName.Text := '';
   NewProductName.Parent := NewProductPage.Surface;

--- a/src/DatabaseMigrator/DatabaseMigrator.csproj
+++ b/src/DatabaseMigrator/DatabaseMigrator.csproj
@@ -59,6 +59,7 @@
     <Compile Include="Migrations\M20150226_AddIsNativeAndProject.cs" />
     <Compile Include="Migrations\M20150304_AddDateTimePortion.cs" />
     <Compile Include="Migrations\M20150303_AddIndexes.cs" />
+    <Compile Include="Migrations\M20150305_IncreaseProjectSize.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Utils.cs" />

--- a/src/DatabaseMigrator/Migrations/M20150305_IncreaseProjectSize.cs
+++ b/src/DatabaseMigrator/Migrations/M20150305_IncreaseProjectSize.cs
@@ -1,0 +1,26 @@
+﻿using FluentMigrator;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Prizm.DatabaseMigrator.Migrations
+{
+   [Migration(20150305)]
+    public class M20150305_IncreaseProjectSize: Migration
+    {
+       public override void Up()
+       {
+           Alter.Table("Project")
+               .AlterColumn("title")
+               .AsString(50);
+       }
+       public override void Down()
+       {
+           Alter.Table("Project")
+               .AlterColumn("title")
+               .AsString(20);
+       }
+    }
+}

--- a/src/PrizmMainProject/Common/LengthLimit.cs
+++ b/src/PrizmMainProject/Common/LengthLimit.cs
@@ -125,7 +125,7 @@ namespace Prizm.Main.Common
         #region ProjectLimits
         public const int MaxProjectClient = 100;
         public const int MaxProjectMillName = 100;
-        public const int MaxProjectTitle = 20;
+        public const int MaxProjectTitle = 50;
         #endregion ProjectLimits
 
         public const int MaxAuditlogUser = 50;


### PR DESCRIPTION
Added migration to increase  to 50 characters field title in Project
table.
Set limit in installer's Project name field
Changed limit in LengthLimit class
Issue: #PRISM-35 Too long project name causes a DB problem
