### PR TITLE
remove Pipes property from PipeMillSizeType #PRISM-33 Fixed

### DIFF
--- a/src/Data/DAL/Mapping/PipeMillSizeTypeMap.cs
+++ b/src/Data/DAL/Mapping/PipeMillSizeTypeMap.cs
@@ -21,7 +21,6 @@ namespace Prizm.Data.DAL.Mapping
             References(x => x.SeamType).Column("seamTypeId").Cascade.SaveUpdate();
             References(x => x.Project).Column("projectId");
 
-            HasMany(x => x.Pipes).KeyColumn("typeId");
             HasMany(_ => _.PipeTests).KeyColumn("pipeMillSizeTypeId").Cascade.All().Inverse().Not.LazyLoad();
         }
     }

--- a/src/Domain/Entity/Setup/PipeMillSizeType.cs
+++ b/src/Domain/Entity/Setup/PipeMillSizeType.cs
@@ -13,7 +13,6 @@ namespace Prizm.Domain.Entity.Setup
         public PipeMillSizeType()
         {
             PipeTests = new List<PipeTest>();
-            Pipes = new List<Pipe>();
         }
         public virtual string Type { get; set; }
         public virtual int Length { get; set; }
@@ -26,7 +25,6 @@ namespace Prizm.Domain.Entity.Setup
 
 
         public virtual IList<PipeTest> PipeTests { get; set; }
-        public virtual IList<Pipe> Pipes { get; set; }
 
         public override string ToString()
         {


### PR DESCRIPTION
PRISM-33 Make sure all Pipes with their cascade information aren't loaded when size type loaded in setup
