### PR TITLE
FirstSetupForm: localization  issue #PRISM-57 Fixed

### DIFF
--- a/src/PrizmMainProject/Forms/MainChildForm/FirstSetupForm/FirstSetupXtraForm.cs
+++ b/src/PrizmMainProject/Forms/MainChildForm/FirstSetupForm/FirstSetupXtraForm.cs
@@ -93,7 +93,6 @@ namespace Prizm.Main.Forms.MainChildForm.FirstSetupForm
                 new LocalizedItem(lastNameLayoutControlItem, StringResources.FirstSetup_LastNameLabel.Id),
                 new LocalizedItem(firstNameLayoutControlItem, StringResources.FirstSetup_FirstNameLabel.Id),
                 new LocalizedItem(middleNameLayoutControlItem, StringResources.FirstSetup_MiddleNameLabel.Id),
-                new LocalizedItem(millLayoutControlItem, StringResources.FirstSetup_MiddleNameLabel.Id),
                 new LocalizedItem(projectLayoutGroup,StringResources.FirstSetup_ProjectGroup.Id),
                 new LocalizedItem(adminLayoutControlGroup, StringResources.FirstSetup_MainAdministratorGroup.Id),
                 


### PR DESCRIPTION
Fixed localization for mill name on FirstSetupXtraForm
Issue:
# PRISM-57 Localization issue: FirstSetupForm, Middle name instead of

Mill name
