### PR TITLE
Wrong language at grid menus after start #PRISM-59 Fixed

### DIFF
--- a/src/PrizmMainProject/Program.cs
+++ b/src/PrizmMainProject/Program.cs
@@ -83,10 +83,7 @@ namespace Prizm.Main
                 return;
             } 
             #endregion
-
-            Thread.CurrentThread.CurrentCulture = LanguageManager.DefaultCultureInfo;
-            Thread.CurrentThread.CurrentUICulture = LanguageManager.DefaultCultureInfo;
-          
+ 
             foreach (var arg in args)
             {
                 if (arg.Equals("seed"))
@@ -109,6 +106,10 @@ namespace Prizm.Main
 
             bool cmdLineMode = false;
             LanguageManager.LoadTranslation(new CultureInfo(Settings.Default.UsersLanguage));
+            
+            Thread.CurrentThread.CurrentCulture = LanguageManager.CurrentCulture;
+            Thread.CurrentThread.CurrentUICulture = LanguageManager.CurrentCulture; 
+
             try
             {
                 // Splash screen


### PR DESCRIPTION
Now DevExpress controls are translated from the beginning.
![112](https://cloud.githubusercontent.com/assets/1634163/6624677/84b69d52-c8f3-11e4-9e06-c2b5a26b814e.png)
In the main app grids are also translated now.

About solution:
We should use CurrentCulture instead of DefaultCultureInfo
CurrentCulture is updated only after first call to LoadTranslation
