### PR TITLE
Audit problem:default choice, RN search  #PRISM-66 Fixed

### DIFF
--- a/src/Data/DAL/Hibernate/AuditLogRepository.cs
+++ b/src/Data/DAL/Hibernate/AuditLogRepository.cs
@@ -76,6 +76,10 @@ namespace Prizm.Data.DAL.Hibernate
                   " union all" +
                   " select id, number from PurchaseOrder WHERE number LIKE CONCAT(:entityNumber, '%')" +
                   " union all" +
+                  " select id, number from ReleaseNote WHERE number LIKE CONCAT(:entityNumber, '%')" +
+                  " union all" +
+                  " select id, number from Railcar WHERE number LIKE CONCAT(:entityNumber, '%')" +
+                  " union all" +
                   " select id,number from Component WHERE number LIKE CONCAT(:entityNumber, '%')) b on a.entityID = b.id" +
                   " where a.auditDate >= :startDate AND a.auditDate <= :endDate").SetResultTransformer(AuditLogQuery.Transformer);
 

--- a/src/PrizmMainProject/Forms/Audit/AuditXtraForm.Designer.cs
+++ b/src/PrizmMainProject/Forms/Audit/AuditXtraForm.Designer.cs
@@ -137,9 +137,6 @@
             this.radioPeriodUser.Name = "radioPeriodUser";
             this.radioPeriodUser.Properties.Appearance.BackColor = System.Drawing.Color.Transparent;
             this.radioPeriodUser.Properties.Appearance.Options.UseBackColor = true;
-            this.radioPeriodUser.Properties.Items.AddRange(new DevExpress.XtraEditors.Controls.RadioGroupItem[] {
-            new DevExpress.XtraEditors.Controls.RadioGroupItem(null, "Номер элемента"),
-            new DevExpress.XtraEditors.Controls.RadioGroupItem(null, "Пользователь")});
             this.radioPeriodUser.Size = new System.Drawing.Size(87, 76);
             this.radioPeriodUser.StyleController = this.searchGroupLayout;
             this.radioPeriodUser.TabIndex = 10;

--- a/src/PrizmMainProject/Forms/Audit/AuditXtraForm.cs
+++ b/src/PrizmMainProject/Forms/Audit/AuditXtraForm.cs
@@ -13,6 +13,7 @@ using Prizm.Main.Commands;
 using Prizm.Main.Common;
 using Prizm.Main.Languages;
 using Prizm.Main.Properties;
+using DevExpress.XtraEditors.Controls;
 
 namespace Prizm.Main.Forms.Audit
 {
@@ -26,13 +27,17 @@ namespace Prizm.Main.Forms.Audit
         {
             InitializeComponent();
             viewModel = (AuditViewModel)Program.Kernel.GetService(typeof(AuditViewModel));
+            viewModel.TracingMode = TracingModeEnum.TracingByNumber;
         }
 
         private void AuditXtraForm_Load(object sender, EventArgs e)
         {
+            foreach (var item in EnumWrapper<TracingModeEnum>.EnumerateItems())
+            {
+                radioPeriodUser.Properties.Items.Add(new RadioGroupItem(item.Item1, item.Item2));
+            }
             BindCommands();
             BindToViewModel();
-
             startDate.SetLimits();
             endDate.SetLimits();
         }
@@ -45,6 +50,7 @@ namespace Prizm.Main.Forms.Audit
             userList.Properties.DataSource = viewModel.UsersList.ToList();
             userList.DataBindings.Add("EditValue", viewModel, "SelectedUser");
             number.DataBindings.Add("EditValue", viewModel, "Number");
+            radioPeriodUser.DataBindings.Add("SelectedIndex", viewModel, "TracingMode");
             number.SetAsIdentifier();
         }
 
@@ -104,19 +110,20 @@ namespace Prizm.Main.Forms.Audit
 
         private void tracingModeRadioGroup_SelectedIndexChanged(object sender, EventArgs e)
         {
-            RadioGroup edit = sender as RadioGroup;
+            if (radioPeriodUser.SelectedIndex < 0)
+                return;
+            var selected = (TracingModeEnum)radioPeriodUser.Properties.Items[radioPeriodUser.SelectedIndex].Value;
+            viewModel.TracingMode = selected;
 
-            if(edit.SelectedIndex == 0)
+            if (radioPeriodUser.SelectedIndex == 0)
             {
                 number.Enabled = true;
                 userList.Enabled = false;
-                viewModel.TracingMode = TracingModeEnum.TracingByNumber;
             }
             else
             {
                 number.Enabled = false;
                 userList.Enabled = true;
-                viewModel.TracingMode = TracingModeEnum.TracingByUser;
             }
         }
 

--- a/src/PrizmMainProject/Languages/LocalizedStrings/Strings.en-US.txt
+++ b/src/PrizmMainProject/Languages/LocalizedStrings/Strings.en-US.txt
@@ -875,7 +875,7 @@ Audit_NumberColumnHeader=Number
 Audit_SearchParametersGroup=Search parameters
 
 ;Аудит. Надпись радиокнопки периода
-Audit_RadioPeriod=Period
+Audit_RadioPeriod=Number
 
 ;Аудит. Надпись радиокнопки пользователя
 Audit_RadioUser=User

--- a/src/PrizmMainProject/Properties/Resources.Designer.cs
+++ b/src/PrizmMainProject/Properties/Resources.Designer.cs
@@ -125,6 +125,24 @@ namespace Prizm.Main.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Номер элемента.
+        /// </summary>
+        internal static string Audit_RadioPeriod {
+            get {
+                return ResourceManager.GetString("Audit_RadioPeriod", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Пользователь.
+        /// </summary>
+        internal static string Audit_RadioUser {
+            get {
+                return ResourceManager.GetString("Audit_RadioUser", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Аудит.
         /// </summary>
         internal static string AuditXtraForm_Title {

--- a/src/PrizmMainProject/Properties/Resources.resx
+++ b/src/PrizmMainProject/Properties/Resources.resx
@@ -1436,4 +1436,10 @@
   <data name="SecurityPrivilege_ViewExportImportHistory" xml:space="preserve">
     <value>Просмотр истории экспорта/импорта</value>
   </data>
+  <data name="Audit_RadioPeriod" xml:space="preserve">
+    <value>Номер элемента</value>
+  </data>
+  <data name="Audit_RadioUser" xml:space="preserve">
+    <value>Пользователь</value>
+  </data>
 </root>


### PR DESCRIPTION
set default choice for search parameters (must be Period)
renamed Period to Number
included release note and railcar numbers in audit search by number
Issue:
# PRISM-66 Audit problems: default choice, release note search
