### PR TITLE
Element number and type read-only #PRISM-81 Fixed

### DIFF
--- a/src/PrizmMainProject/Forms/Parts/Inspection/PartInspectionXtraForm.cs
+++ b/src/PrizmMainProject/Forms/Parts/Inspection/PartInspectionXtraForm.cs
@@ -39,6 +39,8 @@ namespace Prizm.Main.Forms.Parts.Inspection
         {
             InitializeComponent();
             SetAlwaysEditable(searchNumber);
+            SetAlwaysReadOnly(elementType);
+            SetAlwaysReadOnly(elementNumber);
             searchNumber.SetAsIdentifier();
             IsEditMode = true;
         }


### PR DESCRIPTION
Set Element number and element type fields always read-only
Issue:
# PRISM-81 Element number and Element type must not be editable at

Incoming inspection
