### PR TITLE
add binding refresh by OnPropertyChange for jointStatus #PRISM-71 Fixed

### DIFF
--- a/src/PrizmMainProject/Forms/Joint/NewEdit/JointNewEditXtraForm.cs
+++ b/src/PrizmMainProject/Forms/Joint/NewEdit/JointNewEditXtraForm.cs
@@ -107,7 +107,7 @@ namespace Prizm.Main.Forms.Joint.NewEdit
                         "Checked", jointNewEditBindingSoure, "JointIsActive"));
 
             loweringDate.DataBindings
-               .Add("EditValue", jointNewEditBindingSoure, "LoweringDate");
+               .Add("EditValue", jointNewEditBindingSoure, "LoweringDate", true, DataSourceUpdateMode.OnPropertyChanged);
             GPSLat.DataBindings
                 .Add("EditValue", jointNewEditBindingSoure, "GpsLatitude");
             GPSLong.DataBindings
@@ -524,7 +524,6 @@ namespace Prizm.Main.Forms.Joint.NewEdit
                 gv.SetColumnError(weldersGridColumn, Program.LanguageManager.GetString(StringResources.Validation_ValueRequired));
                 e.Valid = false;
             }
-            jointStatus.EditValue = viewModel.JointConstructionStatus;
         }
 
         #region IValidatable Members


### PR DESCRIPTION
PRISM-71 Статус стыка Сварен почему-то меняется на Welded, а в полях Дата  и Сварщики появляются красные пометочки
