### PR TITLE
Tracing report issues (inactive,withdrawn, sorting by number) : #PRISM-87 Fixed  #PRISM-88 Fixed #PRISM-91 Fixed

### DIFF
--- a/src/PrizmMainProject/Forms/Reports/Construction/ConstructionReportViewModel.cs
+++ b/src/PrizmMainProject/Forms/Reports/Construction/ConstructionReportViewModel.cs
@@ -73,7 +73,8 @@ namespace Prizm.Main.Forms.Reports.Construction
             this.partDataList = FormWeldedParts(data);
 
             this.Joints = repoJoint.GetAll()
-                .Where<construct.Joint>(x => x.FirstElement != null && x.SecondElement != null)
+                .Where<construct.Joint>(x => x.FirstElement != null && x.SecondElement != null 
+                    && x.IsActive == true && x.Status != JointStatus.Withdrawn).OrderBy(_ => _.Number)
                 .ToList<construct.Joint>();
             if (this.Joints == null || this.Joints.Count <= 0)
                 log.Warn( "Report at Construction: List of Joints is NULL or empty." );


### PR DESCRIPTION
Removed ability to select inactive or withdrawn joint on tracing report.
Joints are sorted by number
Issues:
# PRISM-87 Отчет по сварке участка между пикетами - при типе По

трассировке по Стыки вылетает с ошибкой (возможно из-за наличия
деактивированных стыков с списке)
# PRISM-88 Отчет по сварке участка между пикетами - при типе По

трассировке по Стыки дроп-дауны с номерами стыков надо сортировать по
возрастанию
# PRISM-91 Отчет по сварке участка между пикетами - при типе По трассировке по Стыки дроп-дауны с номерами стыков должны содержать только активные стыки
