### PR TITLE
Audit interceptor null reference exceptions  #PRISM-84 Fixed, #PRISM-100 Fixed

### DIFF
--- a/src/Data/DAL/Hibernate/AuditInterceptor.cs
+++ b/src/Data/DAL/Hibernate/AuditInterceptor.cs
@@ -80,7 +80,7 @@ namespace Prizm.Data.DAL.Hibernate
                         ||
                         previousState[i] != null && IsAuditableType(previousState[i]))
                     {
-                        if (IsMapLikeComponent(currentState[i]) || IsMapLikeComponent(previousState[i]))
+                        if ((IsMapLikeComponent(currentState[i]) || IsMapLikeComponent(previousState[i])) && currentState[i] != null )
                         {
                             FlushDirtyEntityMapLikeComponent(currentState[i], currentState[i], previousState[i], types);
                             continue;
@@ -243,26 +243,29 @@ namespace Prizm.Data.DAL.Hibernate
         {
             List<string> tempNames = new List<string>();
             List<object> tempCurrentState = new List<object>();
-            List<object> tempPreviousState = new List<object>();
+            List<object> tempPreviousState = (previousState == null) ? null : new List<object>();
 
             var propertyEntity = entity.GetType().GetProperties();
             var propertyCurren = currentState.GetType().GetProperties();
-            var propertyPrevious = previousState.GetType().GetProperties();
+            var propertyPrevious = (previousState == null) ? null : previousState.GetType().GetProperties();
 
             for (int i = 0; i < propertyEntity.Length; ++i)
             {
                 if (propertyEntity[i].Name == "Id") continue;
-                
+
                 tempNames.Add(propertyEntity[i].Name);
                 tempCurrentState.Add(propertyCurren[i].GetValue(currentState));
-                tempPreviousState.Add(propertyPrevious[i].GetValue(previousState));
+                if (propertyPrevious != null)
+                {
+                    tempPreviousState.Add(propertyPrevious[i].GetValue(previousState));
+                }
             }
 
             this.OnFlushDirty(
                 entity,
                 propertyEntity.FirstOrDefault<PropertyInfo>(x => x.Name == "Id").GetValue(entity),
                 tempCurrentState.ToArray(),
-                tempPreviousState.ToArray(),
+                (tempPreviousState == null) ? null : tempPreviousState.ToArray(),
                 tempNames.ToArray(),
                 types);
         }

--- a/src/Domain/Entity/Construction/PartData.cs
+++ b/src/Domain/Entity/Construction/PartData.cs
@@ -10,9 +10,8 @@ using construction = Prizm.Domain.Entity.Construction;
 
 namespace Prizm.Domain.Entity.Construction
 {
-    public class PartData
+    public class PartData : Item
     {
-        public virtual Guid Id { get; set; }
         public virtual PartType PartType { get; set; }
 
         public string Number { get; set; }

--- a/src/Domain/Entity/FieldNames.cs
+++ b/src/Domain/Entity/FieldNames.cs
@@ -111,7 +111,8 @@ namespace Prizm.Domain.Entity
         ExternalCoatSubStatus = 95,
         InternalCoatSubStatus = 96,
         SeamType = 97,
-        Railcar = 98
+        Railcar = 98,
+        PartTypeDescription = 99,
 
     }
 }

--- a/src/Domain/Entity/ItemTypes.cs
+++ b/src/Domain/Entity/ItemTypes.cs
@@ -47,6 +47,6 @@ namespace Prizm.Domain.Entity
         Pipe = 36,
         PipeTestResult = 37,
         PipeMillSizeType = 38,
-
+        PartData = 39
     }
 }


### PR DESCRIPTION
Fixed null reference exceptions caused by audit interceptor.
Issues:
# PRISM-100 Crash at editing Inspection operation at settings
# PRISM-84 Crush at Joint cutting
