### PR TITLE
add dateTimeInfo for all report in header #PRISM-86 Fixed

### DIFF
--- a/src/PrizmMainProject/Forms/Reports/Construction/PipeReport/PipeConstructionXtraReport.Designer.cs
+++ b/src/PrizmMainProject/Forms/Reports/Construction/PipeReport/PipeConstructionXtraReport.Designer.cs
@@ -55,6 +55,7 @@
             this.pageFooter = new DevExpress.XtraReports.UI.PageFooterBand();
             this.numberPageInfo = new DevExpress.XtraReports.UI.XRPageInfo();
             this.dateTimePageInfo = new DevExpress.XtraReports.UI.XRPageInfo();
+            this.PageHeader = new DevExpress.XtraReports.UI.PageHeaderBand();
             ((System.ComponentModel.ISupportInitialize)(this.bindingSource)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this)).BeginInit();
             // 
@@ -150,32 +151,29 @@
             // 
             // TopMargin
             // 
-            this.TopMargin.Controls.AddRange(new DevExpress.XtraReports.UI.XRControl[] {
-            this.reportDateTimeInfo,
-            this.pipeConstructionReportHeader});
-            this.TopMargin.HeightF = 90.00002F;
+            this.TopMargin.HeightF = 48.33336F;
             this.TopMargin.Name = "TopMargin";
             this.TopMargin.Padding = new DevExpress.XtraPrinting.PaddingInfo(0, 0, 0, 0, 100F);
             this.TopMargin.TextAlignment = DevExpress.XtraPrinting.TextAlignment.TopLeft;
             // 
             // reportDateTimeInfo
             // 
-            this.reportDateTimeInfo.Format = "{0:dd-MM-yyyy H:mm:ss}";
-            this.reportDateTimeInfo.LocationFloat = new DevExpress.Utils.PointFloat(505.0596F, 48.25001F);
+            this.reportDateTimeInfo.Format = "Сформирован: {0:dd-MM-yyyy H:mm:ss}";
+            this.reportDateTimeInfo.LocationFloat = new DevExpress.Utils.PointFloat(354.0179F, 0F);
             this.reportDateTimeInfo.Name = "reportDateTimeInfo";
             this.reportDateTimeInfo.Padding = new DevExpress.XtraPrinting.PaddingInfo(2, 2, 0, 0, 100F);
             this.reportDateTimeInfo.PageInfo = DevExpress.XtraPrinting.PageInfo.DateTime;
-            this.reportDateTimeInfo.SizeF = new System.Drawing.SizeF(144.9402F, 41.75002F);
+            this.reportDateTimeInfo.SizeF = new System.Drawing.SizeF(295.9819F, 18.83335F);
             this.reportDateTimeInfo.StylePriority.UseTextAlignment = false;
-            this.reportDateTimeInfo.TextAlignment = DevExpress.XtraPrinting.TextAlignment.BottomRight;
+            this.reportDateTimeInfo.TextAlignment = DevExpress.XtraPrinting.TextAlignment.TopRight;
             // 
             // pipeConstructionReportHeader
             // 
             this.pipeConstructionReportHeader.Font = new System.Drawing.Font("Times New Roman", 20F, System.Drawing.FontStyle.Bold);
-            this.pipeConstructionReportHeader.LocationFloat = new DevExpress.Utils.PointFloat(0F, 48.25001F);
+            this.pipeConstructionReportHeader.LocationFloat = new DevExpress.Utils.PointFloat(0F, 18.83335F);
             this.pipeConstructionReportHeader.Name = "pipeConstructionReportHeader";
             this.pipeConstructionReportHeader.Padding = new DevExpress.XtraPrinting.PaddingInfo(2, 2, 0, 0, 100F);
-            this.pipeConstructionReportHeader.SizeF = new System.Drawing.SizeF(505.0596F, 41.75F);
+            this.pipeConstructionReportHeader.SizeF = new System.Drawing.SizeF(649.9998F, 41.75F);
             this.pipeConstructionReportHeader.StylePriority.UseFont = false;
             this.pipeConstructionReportHeader.StylePriority.UseTextAlignment = false;
             this.pipeConstructionReportHeader.Text = "Отчет по трубам на строительстве";
@@ -191,20 +189,14 @@
             // ReportHeader
             // 
             this.ReportHeader.Controls.AddRange(new DevExpress.XtraReports.UI.XRControl[] {
-            this.secondJointHeader,
-            this.firstJointHeader,
-            this.gradeHeader,
-            this.seamTypeHeader,
-            this.thicknessHeader,
-            this.lengthHeader,
-            this.diameterHeader,
-            this.pipeNumberHeader});
-            this.ReportHeader.HeightF = 38.37497F;
+            this.reportDateTimeInfo,
+            this.pipeConstructionReportHeader});
+            this.ReportHeader.HeightF = 60.58335F;
             this.ReportHeader.Name = "ReportHeader";
             // 
             // secondJointHeader
             // 
-            this.secondJointHeader.LocationFloat = new DevExpress.Utils.PointFloat(589.5833F, 0F);
+            this.secondJointHeader.LocationFloat = new DevExpress.Utils.PointFloat(589.5834F, 0F);
             this.secondJointHeader.Name = "secondJointHeader";
             this.secondJointHeader.Padding = new DevExpress.XtraPrinting.PaddingInfo(2, 2, 0, 0, 100F);
             this.secondJointHeader.SizeF = new System.Drawing.SizeF(60.41667F, 38.37497F);
@@ -220,7 +212,7 @@
             // 
             // gradeHeader
             // 
-            this.gradeHeader.LocationFloat = new DevExpress.Utils.PointFloat(420.5358F, 0F);
+            this.gradeHeader.LocationFloat = new DevExpress.Utils.PointFloat(420.5359F, 0F);
             this.gradeHeader.Name = "gradeHeader";
             this.gradeHeader.Padding = new DevExpress.XtraPrinting.PaddingInfo(2, 2, 0, 0, 100F);
             this.gradeHeader.SizeF = new System.Drawing.SizeF(84.5238F, 38.37497F);
@@ -228,7 +220,7 @@
             // 
             // seamTypeHeader
             // 
-            this.seamTypeHeader.LocationFloat = new DevExpress.Utils.PointFloat(336.012F, 0F);
+            this.seamTypeHeader.LocationFloat = new DevExpress.Utils.PointFloat(336.0121F, 0F);
             this.seamTypeHeader.Name = "seamTypeHeader";
             this.seamTypeHeader.Padding = new DevExpress.XtraPrinting.PaddingInfo(2, 2, 0, 0, 100F);
             this.seamTypeHeader.SizeF = new System.Drawing.SizeF(84.5238F, 38.37497F);
@@ -236,7 +228,7 @@
             // 
             // thicknessHeader
             // 
-            this.thicknessHeader.LocationFloat = new DevExpress.Utils.PointFloat(251.4882F, 0F);
+            this.thicknessHeader.LocationFloat = new DevExpress.Utils.PointFloat(251.4883F, 0F);
             this.thicknessHeader.Name = "thicknessHeader";
             this.thicknessHeader.Padding = new DevExpress.XtraPrinting.PaddingInfo(2, 2, 0, 0, 100F);
             this.thicknessHeader.SizeF = new System.Drawing.SizeF(84.52379F, 38.37497F);
@@ -244,7 +236,7 @@
             // 
             // lengthHeader
             // 
-            this.lengthHeader.LocationFloat = new DevExpress.Utils.PointFloat(166.9644F, 0F);
+            this.lengthHeader.LocationFloat = new DevExpress.Utils.PointFloat(166.9645F, 0F);
             this.lengthHeader.Name = "lengthHeader";
             this.lengthHeader.Padding = new DevExpress.XtraPrinting.PaddingInfo(2, 2, 0, 0, 100F);
             this.lengthHeader.SizeF = new System.Drawing.SizeF(84.5238F, 38.37497F);
@@ -252,7 +244,7 @@
             // 
             // diameterHeader
             // 
-            this.diameterHeader.LocationFloat = new DevExpress.Utils.PointFloat(82.44057F, 0F);
+            this.diameterHeader.LocationFloat = new DevExpress.Utils.PointFloat(82.44063F, 0F);
             this.diameterHeader.Name = "diameterHeader";
             this.diameterHeader.Padding = new DevExpress.XtraPrinting.PaddingInfo(2, 2, 0, 0, 100F);
             this.diameterHeader.SizeF = new System.Drawing.SizeF(84.52382F, 38.37497F);
@@ -260,7 +252,7 @@
             // 
             // pipeNumberHeader
             // 
-            this.pipeNumberHeader.LocationFloat = new DevExpress.Utils.PointFloat(0F, 0F);
+            this.pipeNumberHeader.LocationFloat = new DevExpress.Utils.PointFloat(6.357829E-05F, 0F);
             this.pipeNumberHeader.Name = "pipeNumberHeader";
             this.pipeNumberHeader.Padding = new DevExpress.XtraPrinting.PaddingInfo(2, 2, 0, 0, 100F);
             this.pipeNumberHeader.SizeF = new System.Drawing.SizeF(82.44056F, 38.37497F);
@@ -275,7 +267,7 @@
             this.pageFooter.Controls.AddRange(new DevExpress.XtraReports.UI.XRControl[] {
             this.numberPageInfo,
             this.dateTimePageInfo});
-            this.pageFooter.HeightF = 26.04167F;
+            this.pageFooter.HeightF = 23F;
             this.pageFooter.Name = "pageFooter";
             // 
             // numberPageInfo
@@ -297,6 +289,20 @@
             this.dateTimePageInfo.PageInfo = DevExpress.XtraPrinting.PageInfo.DateTime;
             this.dateTimePageInfo.SizeF = new System.Drawing.SizeF(336.012F, 23F);
             // 
+            // PageHeader
+            // 
+            this.PageHeader.Controls.AddRange(new DevExpress.XtraReports.UI.XRControl[] {
+            this.gradeHeader,
+            this.pipeNumberHeader,
+            this.diameterHeader,
+            this.lengthHeader,
+            this.thicknessHeader,
+            this.seamTypeHeader,
+            this.firstJointHeader,
+            this.secondJointHeader});
+            this.PageHeader.HeightF = 38.37497F;
+            this.PageHeader.Name = "PageHeader";
+            // 
             // PipeConstructionXtraReport
             // 
             this.Bands.AddRange(new DevExpress.XtraReports.UI.Band[] {
@@ -304,9 +310,10 @@
             this.TopMargin,
             this.BottomMargin,
             this.ReportHeader,
-            this.pageFooter});
+            this.pageFooter,
+            this.PageHeader});
             this.DataSource = this.bindingSource;
-            this.Margins = new System.Drawing.Printing.Margins(100, 100, 90, 39);
+            this.Margins = new System.Drawing.Printing.Margins(100, 100, 48, 39);
             this.Version = "14.2";
             ((System.ComponentModel.ISupportInitialize)(this.bindingSource)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this)).EndInit();
@@ -341,5 +348,6 @@
         private DevExpress.XtraReports.UI.XRPageInfo numberPageInfo;
         private DevExpress.XtraReports.UI.XRPageInfo dateTimePageInfo;
         private DevExpress.XtraReports.UI.XRPageInfo reportDateTimeInfo;
+        private DevExpress.XtraReports.UI.PageHeaderBand PageHeader;
     }
 }

--- a/src/PrizmMainProject/Forms/Reports/Construction/PipeReport/PipeConstructionXtraReport.Designer.cs
+++ b/src/PrizmMainProject/Forms/Reports/Construction/PipeReport/PipeConstructionXtraReport.Designer.cs
@@ -39,6 +39,7 @@
             this.pipeNumber = new DevExpress.XtraReports.UI.XRLabel();
             this.seamType = new DevExpress.XtraReports.UI.XRLabel();
             this.TopMargin = new DevExpress.XtraReports.UI.TopMarginBand();
+            this.reportDateTimeInfo = new DevExpress.XtraReports.UI.XRPageInfo();
             this.pipeConstructionReportHeader = new DevExpress.XtraReports.UI.XRLabel();
             this.BottomMargin = new DevExpress.XtraReports.UI.BottomMarginBand();
             this.ReportHeader = new DevExpress.XtraReports.UI.ReportHeaderBand();
@@ -150,11 +151,23 @@
             // TopMargin
             // 
             this.TopMargin.Controls.AddRange(new DevExpress.XtraReports.UI.XRControl[] {
+            this.reportDateTimeInfo,
             this.pipeConstructionReportHeader});
             this.TopMargin.HeightF = 90.00002F;
             this.TopMargin.Name = "TopMargin";
             this.TopMargin.Padding = new DevExpress.XtraPrinting.PaddingInfo(0, 0, 0, 0, 100F);
             this.TopMargin.TextAlignment = DevExpress.XtraPrinting.TextAlignment.TopLeft;
+            // 
+            // reportDateTimeInfo
+            // 
+            this.reportDateTimeInfo.Format = "{0:dd-MM-yyyy H:mm:ss}";
+            this.reportDateTimeInfo.LocationFloat = new DevExpress.Utils.PointFloat(505.0596F, 48.25001F);
+            this.reportDateTimeInfo.Name = "reportDateTimeInfo";
+            this.reportDateTimeInfo.Padding = new DevExpress.XtraPrinting.PaddingInfo(2, 2, 0, 0, 100F);
+            this.reportDateTimeInfo.PageInfo = DevExpress.XtraPrinting.PageInfo.DateTime;
+            this.reportDateTimeInfo.SizeF = new System.Drawing.SizeF(144.9402F, 41.75002F);
+            this.reportDateTimeInfo.StylePriority.UseTextAlignment = false;
+            this.reportDateTimeInfo.TextAlignment = DevExpress.XtraPrinting.TextAlignment.BottomRight;
             // 
             // pipeConstructionReportHeader
             // 
@@ -162,9 +175,11 @@
             this.pipeConstructionReportHeader.LocationFloat = new DevExpress.Utils.PointFloat(0F, 48.25001F);
             this.pipeConstructionReportHeader.Name = "pipeConstructionReportHeader";
             this.pipeConstructionReportHeader.Padding = new DevExpress.XtraPrinting.PaddingInfo(2, 2, 0, 0, 100F);
-            this.pipeConstructionReportHeader.SizeF = new System.Drawing.SizeF(649.9999F, 41.75F);
+            this.pipeConstructionReportHeader.SizeF = new System.Drawing.SizeF(505.0596F, 41.75F);
             this.pipeConstructionReportHeader.StylePriority.UseFont = false;
+            this.pipeConstructionReportHeader.StylePriority.UseTextAlignment = false;
             this.pipeConstructionReportHeader.Text = "Отчет по трубам на строительстве";
+            this.pipeConstructionReportHeader.TextAlignment = DevExpress.XtraPrinting.TextAlignment.BottomLeft;
             // 
             // BottomMargin
             // 
@@ -325,5 +340,6 @@
         private DevExpress.XtraReports.UI.PageFooterBand pageFooter;
         private DevExpress.XtraReports.UI.XRPageInfo numberPageInfo;
         private DevExpress.XtraReports.UI.XRPageInfo dateTimePageInfo;
+        private DevExpress.XtraReports.UI.XRPageInfo reportDateTimeInfo;
     }
 }

--- a/src/PrizmMainProject/Forms/Reports/Construction/TracingReport.Designer.cs
+++ b/src/PrizmMainProject/Forms/Reports/Construction/TracingReport.Designer.cs
@@ -43,6 +43,7 @@
             this.BottomMargin = new DevExpress.XtraReports.UI.BottomMarginBand();
             this.TracingPageHeader = new DevExpress.XtraReports.UI.PageHeaderBand();
             this.tracingPageHeaderXrLabel = new DevExpress.XtraReports.UI.XRLabel();
+            this.reportDateTimeInfo = new DevExpress.XtraReports.UI.XRPageInfo();
             this.TracingGroupHeader = new DevExpress.XtraReports.UI.GroupHeaderBand();
             this.xrLabel12 = new DevExpress.XtraReports.UI.XRLabel();
             this.xrLabel9 = new DevExpress.XtraReports.UI.XRLabel();
@@ -176,7 +177,8 @@
             // TracingPageHeader
             // 
             this.TracingPageHeader.Controls.AddRange(new DevExpress.XtraReports.UI.XRControl[] {
-            this.tracingPageHeaderXrLabel});
+            this.tracingPageHeaderXrLabel,
+            this.reportDateTimeInfo});
             this.TracingPageHeader.HeightF = 50F;
             this.TracingPageHeader.Name = "TracingPageHeader";
             // 
@@ -186,9 +188,22 @@
             this.tracingPageHeaderXrLabel.LocationFloat = new DevExpress.Utils.PointFloat(3.178914E-05F, 0F);
             this.tracingPageHeaderXrLabel.Name = "tracingPageHeaderXrLabel";
             this.tracingPageHeaderXrLabel.Padding = new DevExpress.XtraPrinting.PaddingInfo(2, 2, 0, 0, 100F);
-            this.tracingPageHeaderXrLabel.SizeF = new System.Drawing.SizeF(749.3748F, 50F);
+            this.tracingPageHeaderXrLabel.SizeF = new System.Drawing.SizeF(582.1428F, 50F);
             this.tracingPageHeaderXrLabel.StylePriority.UseFont = false;
+            this.tracingPageHeaderXrLabel.StylePriority.UseTextAlignment = false;
             this.tracingPageHeaderXrLabel.Text = "Трассировка трубопровода";
+            this.tracingPageHeaderXrLabel.TextAlignment = DevExpress.XtraPrinting.TextAlignment.BottomLeft;
+            // 
+            // reportDateTimeInfo
+            // 
+            this.reportDateTimeInfo.Format = "{0:dd-MM-yyyy H:mm:ss}";
+            this.reportDateTimeInfo.LocationFloat = new DevExpress.Utils.PointFloat(584.8215F, 0F);
+            this.reportDateTimeInfo.Name = "reportDateTimeInfo";
+            this.reportDateTimeInfo.Padding = new DevExpress.XtraPrinting.PaddingInfo(2, 2, 0, 0, 100F);
+            this.reportDateTimeInfo.PageInfo = DevExpress.XtraPrinting.PageInfo.DateTime;
+            this.reportDateTimeInfo.SizeF = new System.Drawing.SizeF(164.5533F, 50F);
+            this.reportDateTimeInfo.StylePriority.UseTextAlignment = false;
+            this.reportDateTimeInfo.TextAlignment = DevExpress.XtraPrinting.TextAlignment.BottomRight;
             // 
             // TracingGroupHeader
             // 
@@ -460,5 +475,6 @@
         private DevExpress.XtraReports.UI.PageFooterBand pageFooter;
         private DevExpress.XtraReports.UI.XRPageInfo xrPageInfo2;
         private DevExpress.XtraReports.UI.XRPageInfo xrPageInfo1;
+        private DevExpress.XtraReports.UI.XRPageInfo reportDateTimeInfo;
     }
 }

--- a/src/PrizmMainProject/Forms/Reports/Construction/TracingReport.Designer.cs
+++ b/src/PrizmMainProject/Forms/Reports/Construction/TracingReport.Designer.cs
@@ -179,16 +179,16 @@
             this.TracingPageHeader.Controls.AddRange(new DevExpress.XtraReports.UI.XRControl[] {
             this.tracingPageHeaderXrLabel,
             this.reportDateTimeInfo});
-            this.TracingPageHeader.HeightF = 50F;
+            this.TracingPageHeader.HeightF = 69.79167F;
             this.TracingPageHeader.Name = "TracingPageHeader";
             // 
             // tracingPageHeaderXrLabel
             // 
             this.tracingPageHeaderXrLabel.Font = new System.Drawing.Font("Times New Roman", 20.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(204)));
-            this.tracingPageHeaderXrLabel.LocationFloat = new DevExpress.Utils.PointFloat(3.178914E-05F, 0F);
+            this.tracingPageHeaderXrLabel.LocationFloat = new DevExpress.Utils.PointFloat(0F, 19.79167F);
             this.tracingPageHeaderXrLabel.Name = "tracingPageHeaderXrLabel";
             this.tracingPageHeaderXrLabel.Padding = new DevExpress.XtraPrinting.PaddingInfo(2, 2, 0, 0, 100F);
-            this.tracingPageHeaderXrLabel.SizeF = new System.Drawing.SizeF(582.1428F, 50F);
+            this.tracingPageHeaderXrLabel.SizeF = new System.Drawing.SizeF(750.0001F, 50F);
             this.tracingPageHeaderXrLabel.StylePriority.UseFont = false;
             this.tracingPageHeaderXrLabel.StylePriority.UseTextAlignment = false;
             this.tracingPageHeaderXrLabel.Text = "Трассировка трубопровода";
@@ -196,14 +196,14 @@
             // 
             // reportDateTimeInfo
             // 
-            this.reportDateTimeInfo.Format = "{0:dd-MM-yyyy H:mm:ss}";
-            this.reportDateTimeInfo.LocationFloat = new DevExpress.Utils.PointFloat(584.8215F, 0F);
+            this.reportDateTimeInfo.Format = "Сформирован: {0:dd-MM-yyyy H:mm:ss}";
+            this.reportDateTimeInfo.LocationFloat = new DevExpress.Utils.PointFloat(502.5298F, 0F);
             this.reportDateTimeInfo.Name = "reportDateTimeInfo";
             this.reportDateTimeInfo.Padding = new DevExpress.XtraPrinting.PaddingInfo(2, 2, 0, 0, 100F);
             this.reportDateTimeInfo.PageInfo = DevExpress.XtraPrinting.PageInfo.DateTime;
-            this.reportDateTimeInfo.SizeF = new System.Drawing.SizeF(164.5533F, 50F);
+            this.reportDateTimeInfo.SizeF = new System.Drawing.SizeF(246.845F, 19.79167F);
             this.reportDateTimeInfo.StylePriority.UseTextAlignment = false;
-            this.reportDateTimeInfo.TextAlignment = DevExpress.XtraPrinting.TextAlignment.BottomRight;
+            this.reportDateTimeInfo.TextAlignment = DevExpress.XtraPrinting.TextAlignment.TopRight;
             // 
             // TracingGroupHeader
             // 

--- a/src/PrizmMainProject/Forms/Reports/Construction/UsedProductsXtraReport.Designer.cs
+++ b/src/PrizmMainProject/Forms/Reports/Construction/UsedProductsXtraReport.Designer.cs
@@ -149,10 +149,10 @@
             // groupHeaderLabel
             // 
             this.groupHeaderLabel.Font = new System.Drawing.Font("Segoe UI Semilight", 20F);
-            this.groupHeaderLabel.LocationFloat = new DevExpress.Utils.PointFloat(0F, 0F);
+            this.groupHeaderLabel.LocationFloat = new DevExpress.Utils.PointFloat(0F, 17.79169F);
             this.groupHeaderLabel.Name = "groupHeaderLabel";
             this.groupHeaderLabel.Padding = new DevExpress.XtraPrinting.PaddingInfo(2, 2, 0, 0, 100F);
-            this.groupHeaderLabel.SizeF = new System.Drawing.SizeF(502.0832F, 40.70836F);
+            this.groupHeaderLabel.SizeF = new System.Drawing.SizeF(649.9999F, 40.70836F);
             this.groupHeaderLabel.StyleName = "Header";
             this.groupHeaderLabel.StylePriority.UseFont = false;
             this.groupHeaderLabel.StylePriority.UseTextAlignment = false;
@@ -200,19 +200,19 @@
             this.ReportHeader.Controls.AddRange(new DevExpress.XtraReports.UI.XRControl[] {
             this.groupHeaderLabel,
             this.reportDateTimeInfo});
-            this.ReportHeader.HeightF = 40.70836F;
+            this.ReportHeader.HeightF = 58.50005F;
             this.ReportHeader.Name = "ReportHeader";
             // 
             // reportDateTimeInfo
             // 
-            this.reportDateTimeInfo.Format = "{0:dd-MM-yyyy H:mm:ss}";
-            this.reportDateTimeInfo.LocationFloat = new DevExpress.Utils.PointFloat(502.0832F, 0F);
+            this.reportDateTimeInfo.Format = "Сформирован: {0:dd-MM-yyyy H:mm:ss}";
+            this.reportDateTimeInfo.LocationFloat = new DevExpress.Utils.PointFloat(349.9999F, 0F);
             this.reportDateTimeInfo.Name = "reportDateTimeInfo";
             this.reportDateTimeInfo.Padding = new DevExpress.XtraPrinting.PaddingInfo(2, 2, 0, 0, 100F);
             this.reportDateTimeInfo.PageInfo = DevExpress.XtraPrinting.PageInfo.DateTime;
-            this.reportDateTimeInfo.SizeF = new System.Drawing.SizeF(147.9167F, 40.70836F);
+            this.reportDateTimeInfo.SizeF = new System.Drawing.SizeF(300F, 17.79169F);
             this.reportDateTimeInfo.StylePriority.UseTextAlignment = false;
-            this.reportDateTimeInfo.TextAlignment = DevExpress.XtraPrinting.TextAlignment.BottomRight;
+            this.reportDateTimeInfo.TextAlignment = DevExpress.XtraPrinting.TextAlignment.TopRight;
             // 
             // PageHeader
             // 

--- a/src/PrizmMainProject/Forms/Reports/Construction/UsedProductsXtraReport.Designer.cs
+++ b/src/PrizmMainProject/Forms/Reports/Construction/UsedProductsXtraReport.Designer.cs
@@ -47,6 +47,7 @@
             this.EvenStyle = new DevExpress.XtraReports.UI.XRControlStyle();
             this.TopMargin = new DevExpress.XtraReports.UI.TopMarginBand();
             this.ReportHeader = new DevExpress.XtraReports.UI.ReportHeaderBand();
+            this.reportDateTimeInfo = new DevExpress.XtraReports.UI.XRPageInfo();
             this.PageHeader = new DevExpress.XtraReports.UI.PageHeaderBand();
             this.pageHeaderLabel = new DevExpress.XtraReports.UI.XRLabel();
             this.sqlDataSource1 = new DevExpress.DataAccess.Sql.SqlDataSource();
@@ -151,10 +152,12 @@
             this.groupHeaderLabel.LocationFloat = new DevExpress.Utils.PointFloat(0F, 0F);
             this.groupHeaderLabel.Name = "groupHeaderLabel";
             this.groupHeaderLabel.Padding = new DevExpress.XtraPrinting.PaddingInfo(2, 2, 0, 0, 100F);
-            this.groupHeaderLabel.SizeF = new System.Drawing.SizeF(649.9999F, 40.70836F);
+            this.groupHeaderLabel.SizeF = new System.Drawing.SizeF(502.0832F, 40.70836F);
             this.groupHeaderLabel.StyleName = "Header";
             this.groupHeaderLabel.StylePriority.UseFont = false;
+            this.groupHeaderLabel.StylePriority.UseTextAlignment = false;
             this.groupHeaderLabel.Text = "Отчет по использованным изделиям";
+            this.groupHeaderLabel.TextAlignment = DevExpress.XtraPrinting.TextAlignment.BottomLeft;
             // 
             // Header
             // 
@@ -195,9 +198,21 @@
             // ReportHeader
             // 
             this.ReportHeader.Controls.AddRange(new DevExpress.XtraReports.UI.XRControl[] {
-            this.groupHeaderLabel});
+            this.groupHeaderLabel,
+            this.reportDateTimeInfo});
             this.ReportHeader.HeightF = 40.70836F;
             this.ReportHeader.Name = "ReportHeader";
+            // 
+            // reportDateTimeInfo
+            // 
+            this.reportDateTimeInfo.Format = "{0:dd-MM-yyyy H:mm:ss}";
+            this.reportDateTimeInfo.LocationFloat = new DevExpress.Utils.PointFloat(502.0832F, 0F);
+            this.reportDateTimeInfo.Name = "reportDateTimeInfo";
+            this.reportDateTimeInfo.Padding = new DevExpress.XtraPrinting.PaddingInfo(2, 2, 0, 0, 100F);
+            this.reportDateTimeInfo.PageInfo = DevExpress.XtraPrinting.PageInfo.DateTime;
+            this.reportDateTimeInfo.SizeF = new System.Drawing.SizeF(147.9167F, 40.70836F);
+            this.reportDateTimeInfo.StylePriority.UseTextAlignment = false;
+            this.reportDateTimeInfo.TextAlignment = DevExpress.XtraPrinting.TextAlignment.BottomRight;
             // 
             // PageHeader
             // 
@@ -216,7 +231,9 @@
             this.pageHeaderLabel.SizeF = new System.Drawing.SizeF(649.9999F, 40.70836F);
             this.pageHeaderLabel.StyleName = "Header";
             this.pageHeaderLabel.StylePriority.UseFont = false;
+            this.pageHeaderLabel.StylePriority.UseTextAlignment = false;
             this.pageHeaderLabel.Text = "Отчет по использованным изделиям";
+            this.pageHeaderLabel.TextAlignment = DevExpress.XtraPrinting.TextAlignment.BottomLeft;
             // 
             // sqlDataSource1
             // 
@@ -275,6 +292,7 @@
         private DevExpress.XtraReports.UI.XRLabel productNumberLabel;
         private DevExpress.DataAccess.Sql.SqlDataSource sqlDataSource1;
         private DevExpress.XtraReports.UI.XRPageInfo dateTimePageInfo;
+        private DevExpress.XtraReports.UI.XRPageInfo reportDateTimeInfo;
 
     }
 }

--- a/src/PrizmMainProject/Forms/Reports/Construction/WeldDateReports/WeldDateXtraReport.Designer.cs
+++ b/src/PrizmMainProject/Forms/Reports/Construction/WeldDateReports/WeldDateXtraReport.Designer.cs
@@ -31,13 +31,14 @@
             this.components = new System.ComponentModel.Container();
             this.Detail = new DevExpress.XtraReports.UI.DetailBand();
             this.dateXrLabel = new DevExpress.XtraReports.UI.XRLabel();
-            this.firstPartLengthXrLabel = new DevExpress.XtraReports.UI.XRLabel();
             this.secondPartNumberXrLabel = new DevExpress.XtraReports.UI.XRLabel();
             this.firstNumberXrLabel = new DevExpress.XtraReports.UI.XRLabel();
             this.jointNumberXrLabel = new DevExpress.XtraReports.UI.XRLabel();
             this.secondPartLengthXrLabel = new DevExpress.XtraReports.UI.XRLabel();
+            this.firstPartLengthXrLabel = new DevExpress.XtraReports.UI.XRLabel();
             this.dateHeader = new DevExpress.XtraReports.UI.XRLabel();
             this.TopMargin = new DevExpress.XtraReports.UI.TopMarginBand();
+            this.reportDateTimeInfo = new DevExpress.XtraReports.UI.XRPageInfo();
             this.weldReportByDateHeader = new DevExpress.XtraReports.UI.XRLabel();
             this.BottomMargin = new DevExpress.XtraReports.UI.BottomMarginBand();
             this.jointNumberHeader = new DevExpress.XtraReports.UI.XRLabel();
@@ -78,15 +79,6 @@
             this.dateXrLabel.Padding = new DevExpress.XtraPrinting.PaddingInfo(2, 2, 0, 0, 100F);
             this.dateXrLabel.SizeF = new System.Drawing.SizeF(96.45831F, 23F);
             // 
-            // firstPartLengthXrLabel
-            // 
-            this.firstPartLengthXrLabel.DataBindings.AddRange(new DevExpress.XtraReports.UI.XRBinding[] {
-            new DevExpress.XtraReports.UI.XRBinding("Text", null, "FipstPartLength")});
-            this.firstPartLengthXrLabel.LocationFloat = new DevExpress.Utils.PointFloat(421.9167F, 0F);
-            this.firstPartLengthXrLabel.Name = "firstPartLengthXrLabel";
-            this.firstPartLengthXrLabel.Padding = new DevExpress.XtraPrinting.PaddingInfo(2, 2, 0, 0, 100F);
-            this.firstPartLengthXrLabel.SizeF = new System.Drawing.SizeF(109.375F, 23F);
-            // 
             // secondPartNumberXrLabel
             // 
             this.secondPartNumberXrLabel.DataBindings.AddRange(new DevExpress.XtraReports.UI.XRBinding[] {
@@ -123,6 +115,15 @@
             this.secondPartLengthXrLabel.Padding = new DevExpress.XtraPrinting.PaddingInfo(2, 2, 0, 0, 100F);
             this.secondPartLengthXrLabel.SizeF = new System.Drawing.SizeF(118.7083F, 23F);
             // 
+            // firstPartLengthXrLabel
+            // 
+            this.firstPartLengthXrLabel.DataBindings.AddRange(new DevExpress.XtraReports.UI.XRBinding[] {
+            new DevExpress.XtraReports.UI.XRBinding("Text", null, "FipstPartLength")});
+            this.firstPartLengthXrLabel.LocationFloat = new DevExpress.Utils.PointFloat(421.9167F, 0F);
+            this.firstPartLengthXrLabel.Name = "firstPartLengthXrLabel";
+            this.firstPartLengthXrLabel.Padding = new DevExpress.XtraPrinting.PaddingInfo(2, 2, 0, 0, 100F);
+            this.firstPartLengthXrLabel.SizeF = new System.Drawing.SizeF(109.375F, 23F);
+            // 
             // dateHeader
             // 
             this.dateHeader.LocationFloat = new DevExpress.Utils.PointFloat(0F, 0F);
@@ -134,11 +135,23 @@
             // TopMargin
             // 
             this.TopMargin.Controls.AddRange(new DevExpress.XtraReports.UI.XRControl[] {
+            this.reportDateTimeInfo,
             this.weldReportByDateHeader});
             this.TopMargin.HeightF = 45F;
             this.TopMargin.Name = "TopMargin";
             this.TopMargin.Padding = new DevExpress.XtraPrinting.PaddingInfo(0, 0, 0, 0, 100F);
             this.TopMargin.TextAlignment = DevExpress.XtraPrinting.TextAlignment.TopLeft;
+            // 
+            // reportDateTimeInfo
+            // 
+            this.reportDateTimeInfo.Format = "{0:dd-MM-yyyy H:mm:ss}";
+            this.reportDateTimeInfo.LocationFloat = new DevExpress.Utils.PointFloat(497.9165F, 0F);
+            this.reportDateTimeInfo.Name = "reportDateTimeInfo";
+            this.reportDateTimeInfo.Padding = new DevExpress.XtraPrinting.PaddingInfo(2, 2, 0, 0, 100F);
+            this.reportDateTimeInfo.PageInfo = DevExpress.XtraPrinting.PageInfo.DateTime;
+            this.reportDateTimeInfo.SizeF = new System.Drawing.SizeF(152.0835F, 43.83334F);
+            this.reportDateTimeInfo.StylePriority.UseTextAlignment = false;
+            this.reportDateTimeInfo.TextAlignment = DevExpress.XtraPrinting.TextAlignment.BottomRight;
             // 
             // weldReportByDateHeader
             // 
@@ -146,9 +159,11 @@
             this.weldReportByDateHeader.LocationFloat = new DevExpress.Utils.PointFloat(0F, 0F);
             this.weldReportByDateHeader.Name = "weldReportByDateHeader";
             this.weldReportByDateHeader.Padding = new DevExpress.XtraPrinting.PaddingInfo(2, 2, 0, 0, 100F);
-            this.weldReportByDateHeader.SizeF = new System.Drawing.SizeF(649.9999F, 43.83334F);
+            this.weldReportByDateHeader.SizeF = new System.Drawing.SizeF(497.9165F, 43.83334F);
             this.weldReportByDateHeader.StylePriority.UseFont = false;
+            this.weldReportByDateHeader.StylePriority.UseTextAlignment = false;
             this.weldReportByDateHeader.Text = "Отчет по сварке (по дате)";
+            this.weldReportByDateHeader.TextAlignment = DevExpress.XtraPrinting.TextAlignment.BottomLeft;
             // 
             // BottomMargin
             // 
@@ -279,5 +294,6 @@
         private DevExpress.XtraReports.UI.PageFooterBand pageFooter;
         private DevExpress.XtraReports.UI.XRPageInfo numberOfPageInfo;
         private DevExpress.XtraReports.UI.XRPageInfo dateTimePageInfo;
+        private DevExpress.XtraReports.UI.XRPageInfo reportDateTimeInfo;
     }
 }

--- a/src/PrizmMainProject/Forms/Reports/Construction/WeldDateReports/WeldDateXtraReport.Designer.cs
+++ b/src/PrizmMainProject/Forms/Reports/Construction/WeldDateReports/WeldDateXtraReport.Designer.cs
@@ -51,6 +51,7 @@
             this.numberOfPageInfo = new DevExpress.XtraReports.UI.XRPageInfo();
             this.dateTimePageInfo = new DevExpress.XtraReports.UI.XRPageInfo();
             this.bindingSource = new System.Windows.Forms.BindingSource(this.components);
+            this.PageHeader = new DevExpress.XtraReports.UI.PageHeaderBand();
             ((System.ComponentModel.ISupportInitialize)(this.bindingSource)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this)).BeginInit();
             // 
@@ -134,9 +135,6 @@
             // 
             // TopMargin
             // 
-            this.TopMargin.Controls.AddRange(new DevExpress.XtraReports.UI.XRControl[] {
-            this.reportDateTimeInfo,
-            this.weldReportByDateHeader});
             this.TopMargin.HeightF = 45F;
             this.TopMargin.Name = "TopMargin";
             this.TopMargin.Padding = new DevExpress.XtraPrinting.PaddingInfo(0, 0, 0, 0, 100F);
@@ -144,22 +142,22 @@
             // 
             // reportDateTimeInfo
             // 
-            this.reportDateTimeInfo.Format = "{0:dd-MM-yyyy H:mm:ss}";
-            this.reportDateTimeInfo.LocationFloat = new DevExpress.Utils.PointFloat(497.9165F, 0F);
+            this.reportDateTimeInfo.Format = "Сформирован: {0:dd-MM-yyyy H:mm:ss}";
+            this.reportDateTimeInfo.LocationFloat = new DevExpress.Utils.PointFloat(402.0832F, 0F);
             this.reportDateTimeInfo.Name = "reportDateTimeInfo";
             this.reportDateTimeInfo.Padding = new DevExpress.XtraPrinting.PaddingInfo(2, 2, 0, 0, 100F);
             this.reportDateTimeInfo.PageInfo = DevExpress.XtraPrinting.PageInfo.DateTime;
-            this.reportDateTimeInfo.SizeF = new System.Drawing.SizeF(152.0835F, 43.83334F);
+            this.reportDateTimeInfo.SizeF = new System.Drawing.SizeF(247.9168F, 17.79167F);
             this.reportDateTimeInfo.StylePriority.UseTextAlignment = false;
-            this.reportDateTimeInfo.TextAlignment = DevExpress.XtraPrinting.TextAlignment.BottomRight;
+            this.reportDateTimeInfo.TextAlignment = DevExpress.XtraPrinting.TextAlignment.TopRight;
             // 
             // weldReportByDateHeader
             // 
             this.weldReportByDateHeader.Font = new System.Drawing.Font("Times New Roman", 20F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(204)));
-            this.weldReportByDateHeader.LocationFloat = new DevExpress.Utils.PointFloat(0F, 0F);
+            this.weldReportByDateHeader.LocationFloat = new DevExpress.Utils.PointFloat(0F, 17.79167F);
             this.weldReportByDateHeader.Name = "weldReportByDateHeader";
             this.weldReportByDateHeader.Padding = new DevExpress.XtraPrinting.PaddingInfo(2, 2, 0, 0, 100F);
-            this.weldReportByDateHeader.SizeF = new System.Drawing.SizeF(497.9165F, 43.83334F);
+            this.weldReportByDateHeader.SizeF = new System.Drawing.SizeF(650.0001F, 43.83334F);
             this.weldReportByDateHeader.StylePriority.UseFont = false;
             this.weldReportByDateHeader.StylePriority.UseTextAlignment = false;
             this.weldReportByDateHeader.Text = "Отчет по сварке (по дате)";
@@ -174,7 +172,7 @@
             // 
             // jointNumberHeader
             // 
-            this.jointNumberHeader.LocationFloat = new DevExpress.Utils.PointFloat(96.45831F, 0F);
+            this.jointNumberHeader.LocationFloat = new DevExpress.Utils.PointFloat(96.45824F, 0F);
             this.jointNumberHeader.Name = "jointNumberHeader";
             this.jointNumberHeader.Padding = new DevExpress.XtraPrinting.PaddingInfo(2, 2, 0, 0, 100F);
             this.jointNumberHeader.SizeF = new System.Drawing.SizeF(105.2083F, 34.2083F);
@@ -182,7 +180,7 @@
             // 
             // firstPartNumberHeader
             // 
-            this.firstPartNumberHeader.LocationFloat = new DevExpress.Utils.PointFloat(201.6666F, 0F);
+            this.firstPartNumberHeader.LocationFloat = new DevExpress.Utils.PointFloat(201.6665F, 0F);
             this.firstPartNumberHeader.Name = "firstPartNumberHeader";
             this.firstPartNumberHeader.Padding = new DevExpress.XtraPrinting.PaddingInfo(2, 2, 0, 0, 100F);
             this.firstPartNumberHeader.SizeF = new System.Drawing.SizeF(106.25F, 34.2083F);
@@ -206,7 +204,7 @@
             // 
             // secondPartLengthHeader
             // 
-            this.secondPartLengthHeader.LocationFloat = new DevExpress.Utils.PointFloat(531.2917F, 0F);
+            this.secondPartLengthHeader.LocationFloat = new DevExpress.Utils.PointFloat(531.2916F, 0F);
             this.secondPartLengthHeader.Name = "secondPartLengthHeader";
             this.secondPartLengthHeader.Padding = new DevExpress.XtraPrinting.PaddingInfo(2, 2, 0, 0, 100F);
             this.secondPartLengthHeader.SizeF = new System.Drawing.SizeF(118.7083F, 34.2083F);
@@ -215,13 +213,9 @@
             // ReportHeader
             // 
             this.ReportHeader.Controls.AddRange(new DevExpress.XtraReports.UI.XRControl[] {
-            this.dateHeader,
-            this.secondPartLengthHeader,
-            this.firstPartNumberHeader,
-            this.secondPartNumberHeader,
-            this.firstPartLengthHeader,
-            this.jointNumberHeader});
-            this.ReportHeader.HeightF = 34.375F;
+            this.weldReportByDateHeader,
+            this.reportDateTimeInfo});
+            this.ReportHeader.HeightF = 61.625F;
             this.ReportHeader.Name = "ReportHeader";
             // 
             // pageFooter
@@ -255,6 +249,18 @@
             // 
             this.bindingSource.DataSource = typeof(Prizm.Main.Forms.Reports.Construction.WeldDateReports.WeldDateReportData);
             // 
+            // PageHeader
+            // 
+            this.PageHeader.Controls.AddRange(new DevExpress.XtraReports.UI.XRControl[] {
+            this.secondPartLengthHeader,
+            this.firstPartLengthHeader,
+            this.secondPartNumberHeader,
+            this.firstPartNumberHeader,
+            this.jointNumberHeader,
+            this.dateHeader});
+            this.PageHeader.HeightF = 34.375F;
+            this.PageHeader.Name = "PageHeader";
+            // 
             // WeldDateXtraReport
             // 
             this.Bands.AddRange(new DevExpress.XtraReports.UI.Band[] {
@@ -262,7 +268,8 @@
             this.TopMargin,
             this.BottomMargin,
             this.ReportHeader,
-            this.pageFooter});
+            this.pageFooter,
+            this.PageHeader});
             this.DataSource = this.bindingSource;
             this.Margins = new System.Drawing.Printing.Margins(100, 100, 45, 36);
             this.Version = "14.2";
@@ -295,5 +302,6 @@
         private DevExpress.XtraReports.UI.XRPageInfo numberOfPageInfo;
         private DevExpress.XtraReports.UI.XRPageInfo dateTimePageInfo;
         private DevExpress.XtraReports.UI.XRPageInfo reportDateTimeInfo;
+        private DevExpress.XtraReports.UI.PageHeaderBand PageHeader;
     }
 }

--- a/src/PrizmMainProject/Forms/Reports/Incoming/IncomingReportsXtraReport.Designer.cs
+++ b/src/PrizmMainProject/Forms/Reports/Incoming/IncomingReportsXtraReport.Designer.cs
@@ -50,6 +50,7 @@
             this.numberOfPageInfo = new DevExpress.XtraReports.UI.XRPageInfo();
             this.reportHeader = new DevExpress.XtraReports.UI.ReportHeaderBand();
             this.reportHeaderLabel = new DevExpress.XtraReports.UI.XRLabel();
+            this.reportDateTimeInfo = new DevExpress.XtraReports.UI.XRPageInfo();
             this.Title = new DevExpress.XtraReports.UI.XRControlStyle();
             this.FieldCaption = new DevExpress.XtraReports.UI.XRControlStyle();
             this.PageInfo = new DevExpress.XtraReports.UI.XRControlStyle();
@@ -247,7 +248,8 @@
             // reportHeader
             // 
             this.reportHeader.Controls.AddRange(new DevExpress.XtraReports.UI.XRControl[] {
-            this.reportHeaderLabel});
+            this.reportHeaderLabel,
+            this.reportDateTimeInfo});
             this.reportHeader.HeightF = 33F;
             this.reportHeader.Name = "reportHeader";
             // 
@@ -257,10 +259,21 @@
             this.reportHeaderLabel.LocationFloat = new DevExpress.Utils.PointFloat(0F, 0F);
             this.reportHeaderLabel.Name = "reportHeaderLabel";
             this.reportHeaderLabel.Padding = new DevExpress.XtraPrinting.PaddingInfo(2, 2, 0, 0, 100F);
-            this.reportHeaderLabel.SizeF = new System.Drawing.SizeF(748F, 33F);
+            this.reportHeaderLabel.SizeF = new System.Drawing.SizeF(550.0834F, 33F);
             this.reportHeaderLabel.StyleName = "Title";
             this.reportHeaderLabel.StylePriority.UseForeColor = false;
             this.reportHeaderLabel.Text = "Отчет по входному контролю";
+            // 
+            // reportDateTimeInfo
+            // 
+            this.reportDateTimeInfo.Format = "{0:dd-MM-yyyy H:mm:ss}";
+            this.reportDateTimeInfo.LocationFloat = new DevExpress.Utils.PointFloat(550.0834F, 0F);
+            this.reportDateTimeInfo.Name = "reportDateTimeInfo";
+            this.reportDateTimeInfo.Padding = new DevExpress.XtraPrinting.PaddingInfo(2, 2, 0, 0, 100F);
+            this.reportDateTimeInfo.PageInfo = DevExpress.XtraPrinting.PageInfo.DateTime;
+            this.reportDateTimeInfo.SizeF = new System.Drawing.SizeF(197.9164F, 33F);
+            this.reportDateTimeInfo.StylePriority.UseTextAlignment = false;
+            this.reportDateTimeInfo.TextAlignment = DevExpress.XtraPrinting.TextAlignment.BottomRight;
             // 
             // Title
             // 
@@ -355,5 +368,6 @@
         private DevExpress.XtraReports.UI.XRControlStyle FieldCaption;
         private DevExpress.XtraReports.UI.XRControlStyle PageInfo;
         private DevExpress.XtraReports.UI.XRControlStyle DataField;
+        private DevExpress.XtraReports.UI.XRPageInfo reportDateTimeInfo;
     }
 }

--- a/src/PrizmMainProject/Forms/Reports/Incoming/IncomingReportsXtraReport.Designer.cs
+++ b/src/PrizmMainProject/Forms/Reports/Incoming/IncomingReportsXtraReport.Designer.cs
@@ -250,30 +250,30 @@
             this.reportHeader.Controls.AddRange(new DevExpress.XtraReports.UI.XRControl[] {
             this.reportHeaderLabel,
             this.reportDateTimeInfo});
-            this.reportHeader.HeightF = 33F;
+            this.reportHeader.HeightF = 50.37501F;
             this.reportHeader.Name = "reportHeader";
             // 
             // reportHeaderLabel
             // 
             this.reportHeaderLabel.ForeColor = System.Drawing.Color.Black;
-            this.reportHeaderLabel.LocationFloat = new DevExpress.Utils.PointFloat(0F, 0F);
+            this.reportHeaderLabel.LocationFloat = new DevExpress.Utils.PointFloat(1.000277F, 17.37501F);
             this.reportHeaderLabel.Name = "reportHeaderLabel";
             this.reportHeaderLabel.Padding = new DevExpress.XtraPrinting.PaddingInfo(2, 2, 0, 0, 100F);
-            this.reportHeaderLabel.SizeF = new System.Drawing.SizeF(550.0834F, 33F);
+            this.reportHeaderLabel.SizeF = new System.Drawing.SizeF(747.9998F, 33F);
             this.reportHeaderLabel.StyleName = "Title";
             this.reportHeaderLabel.StylePriority.UseForeColor = false;
             this.reportHeaderLabel.Text = "Отчет по входному контролю";
             // 
             // reportDateTimeInfo
             // 
-            this.reportDateTimeInfo.Format = "{0:dd-MM-yyyy H:mm:ss}";
-            this.reportDateTimeInfo.LocationFloat = new DevExpress.Utils.PointFloat(550.0834F, 0F);
+            this.reportDateTimeInfo.Format = "Сформирован: {0:dd-MM-yyyy H:mm:ss}";
+            this.reportDateTimeInfo.LocationFloat = new DevExpress.Utils.PointFloat(449.012F, 0F);
             this.reportDateTimeInfo.Name = "reportDateTimeInfo";
             this.reportDateTimeInfo.Padding = new DevExpress.XtraPrinting.PaddingInfo(2, 2, 0, 0, 100F);
             this.reportDateTimeInfo.PageInfo = DevExpress.XtraPrinting.PageInfo.DateTime;
-            this.reportDateTimeInfo.SizeF = new System.Drawing.SizeF(197.9164F, 33F);
+            this.reportDateTimeInfo.SizeF = new System.Drawing.SizeF(298.9878F, 17.375F);
             this.reportDateTimeInfo.StylePriority.UseTextAlignment = false;
-            this.reportDateTimeInfo.TextAlignment = DevExpress.XtraPrinting.TextAlignment.BottomRight;
+            this.reportDateTimeInfo.TextAlignment = DevExpress.XtraPrinting.TextAlignment.TopRight;
             // 
             // Title
             // 

--- a/src/PrizmMainProject/Forms/Reports/Mill/GeneralInformationXtraReport.Designer.cs
+++ b/src/PrizmMainProject/Forms/Reports/Mill/GeneralInformationXtraReport.Designer.cs
@@ -68,6 +68,7 @@
             this.xrPageInfo1 = new DevExpress.XtraReports.UI.XRPageInfo();
             this.xrPageInfo2 = new DevExpress.XtraReports.UI.XRPageInfo();
             this.reportHeaderBand1 = new DevExpress.XtraReports.UI.ReportHeaderBand();
+            this.reportDateTimeInfo = new DevExpress.XtraReports.UI.XRPageInfo();
             this.xrLabel33 = new DevExpress.XtraReports.UI.XRLabel();
             this.Title = new DevExpress.XtraReports.UI.XRControlStyle();
             this.FieldCaption = new DevExpress.XtraReports.UI.XRControlStyle();
@@ -457,9 +458,23 @@
             // reportHeaderBand1
             // 
             this.reportHeaderBand1.Controls.AddRange(new DevExpress.XtraReports.UI.XRControl[] {
+            this.reportDateTimeInfo,
             this.xrLabel33});
-            this.reportHeaderBand1.HeightF = 33F;
+            this.reportHeaderBand1.HeightF = 33.00001F;
             this.reportHeaderBand1.Name = "reportHeaderBand1";
+            // 
+            // reportDateTimeInfo
+            // 
+            this.reportDateTimeInfo.Font = new System.Drawing.Font("Times New Roman", 10F, System.Drawing.FontStyle.Bold);
+            this.reportDateTimeInfo.Format = "{0:dd-MM-yyyy H:mm:ss}";
+            this.reportDateTimeInfo.LocationFloat = new DevExpress.Utils.PointFloat(866.308F, 0F);
+            this.reportDateTimeInfo.Name = "reportDateTimeInfo";
+            this.reportDateTimeInfo.Padding = new DevExpress.XtraPrinting.PaddingInfo(2, 2, 0, 0, 100F);
+            this.reportDateTimeInfo.PageInfo = DevExpress.XtraPrinting.PageInfo.DateTime;
+            this.reportDateTimeInfo.SizeF = new System.Drawing.SizeF(166.6919F, 33F);
+            this.reportDateTimeInfo.StylePriority.UseFont = false;
+            this.reportDateTimeInfo.StylePriority.UseTextAlignment = false;
+            this.reportDateTimeInfo.TextAlignment = DevExpress.XtraPrinting.TextAlignment.BottomRight;
             // 
             // xrLabel33
             // 
@@ -467,7 +482,7 @@
             this.xrLabel33.LocationFloat = new DevExpress.Utils.PointFloat(0F, 0F);
             this.xrLabel33.Name = "xrLabel33";
             this.xrLabel33.Padding = new DevExpress.XtraPrinting.PaddingInfo(2, 2, 0, 0, 100F);
-            this.xrLabel33.SizeF = new System.Drawing.SizeF(1033F, 33F);
+            this.xrLabel33.SizeF = new System.Drawing.SizeF(866.3079F, 33F);
             this.xrLabel33.StyleName = "Title";
             this.xrLabel33.StylePriority.UseForeColor = false;
             this.xrLabel33.Text = "Отчет по заводу";
@@ -609,5 +624,6 @@
         private DevExpress.XtraReports.UI.XRLabel xrLabel35;
         private DevExpress.XtraReports.UI.XRLabel xrLabel34;
         private DevExpress.XtraReports.UI.GroupHeaderBand GroupHeader1;
+        private DevExpress.XtraReports.UI.XRPageInfo reportDateTimeInfo;
     }
 }

--- a/src/PrizmMainProject/Forms/Reports/Mill/GeneralInformationXtraReport.Designer.cs
+++ b/src/PrizmMainProject/Forms/Reports/Mill/GeneralInformationXtraReport.Designer.cs
@@ -257,7 +257,7 @@
             // 
             // pageHeaderBand1
             // 
-            this.pageHeaderBand1.HeightF = 48.29165F;
+            this.pageHeaderBand1.HeightF = 28.49998F;
             this.pageHeaderBand1.Name = "pageHeaderBand1";
             // 
             // xrLabel7
@@ -460,29 +460,29 @@
             this.reportHeaderBand1.Controls.AddRange(new DevExpress.XtraReports.UI.XRControl[] {
             this.reportDateTimeInfo,
             this.xrLabel33});
-            this.reportHeaderBand1.HeightF = 33.00001F;
+            this.reportHeaderBand1.HeightF = 48.29166F;
             this.reportHeaderBand1.Name = "reportHeaderBand1";
             // 
             // reportDateTimeInfo
             // 
             this.reportDateTimeInfo.Font = new System.Drawing.Font("Times New Roman", 10F, System.Drawing.FontStyle.Bold);
-            this.reportDateTimeInfo.Format = "{0:dd-MM-yyyy H:mm:ss}";
-            this.reportDateTimeInfo.LocationFloat = new DevExpress.Utils.PointFloat(866.308F, 0F);
+            this.reportDateTimeInfo.Format = "Сформирован: {0:dd-MM-yyyy H:mm:ss}";
+            this.reportDateTimeInfo.LocationFloat = new DevExpress.Utils.PointFloat(750.683F, 0F);
             this.reportDateTimeInfo.Name = "reportDateTimeInfo";
             this.reportDateTimeInfo.Padding = new DevExpress.XtraPrinting.PaddingInfo(2, 2, 0, 0, 100F);
             this.reportDateTimeInfo.PageInfo = DevExpress.XtraPrinting.PageInfo.DateTime;
-            this.reportDateTimeInfo.SizeF = new System.Drawing.SizeF(166.6919F, 33F);
+            this.reportDateTimeInfo.SizeF = new System.Drawing.SizeF(282.3169F, 15.29167F);
             this.reportDateTimeInfo.StylePriority.UseFont = false;
             this.reportDateTimeInfo.StylePriority.UseTextAlignment = false;
-            this.reportDateTimeInfo.TextAlignment = DevExpress.XtraPrinting.TextAlignment.BottomRight;
+            this.reportDateTimeInfo.TextAlignment = DevExpress.XtraPrinting.TextAlignment.TopRight;
             // 
             // xrLabel33
             // 
             this.xrLabel33.ForeColor = System.Drawing.Color.Black;
-            this.xrLabel33.LocationFloat = new DevExpress.Utils.PointFloat(0F, 0F);
+            this.xrLabel33.LocationFloat = new DevExpress.Utils.PointFloat(0F, 15.29166F);
             this.xrLabel33.Name = "xrLabel33";
             this.xrLabel33.Padding = new DevExpress.XtraPrinting.PaddingInfo(2, 2, 0, 0, 100F);
-            this.xrLabel33.SizeF = new System.Drawing.SizeF(866.3079F, 33F);
+            this.xrLabel33.SizeF = new System.Drawing.SizeF(1033F, 33F);
             this.xrLabel33.StyleName = "Title";
             this.xrLabel33.StylePriority.UseForeColor = false;
             this.xrLabel33.Text = "Отчет по заводу";

--- a/src/PrizmMainProject/Forms/Reports/Mill/LoadingXtraReport.Designer.cs
+++ b/src/PrizmMainProject/Forms/Reports/Mill/LoadingXtraReport.Designer.cs
@@ -49,6 +49,7 @@
             this.xrPageInfo1 = new DevExpress.XtraReports.UI.XRPageInfo();
             this.xrPageInfo2 = new DevExpress.XtraReports.UI.XRPageInfo();
             this.reportHeaderBand1 = new DevExpress.XtraReports.UI.ReportHeaderBand();
+            this.reportDateTimeInfo = new DevExpress.XtraReports.UI.XRPageInfo();
             this.xrLabel5 = new DevExpress.XtraReports.UI.XRLabel();
             this.Title = new DevExpress.XtraReports.UI.XRControlStyle();
             this.FieldCaption = new DevExpress.XtraReports.UI.XRControlStyle();
@@ -234,9 +235,23 @@
             // reportHeaderBand1
             // 
             this.reportHeaderBand1.Controls.AddRange(new DevExpress.XtraReports.UI.XRControl[] {
+            this.reportDateTimeInfo,
             this.xrLabel5});
             this.reportHeaderBand1.HeightF = 33.29166F;
             this.reportHeaderBand1.Name = "reportHeaderBand1";
+            // 
+            // reportDateTimeInfo
+            // 
+            this.reportDateTimeInfo.Font = new System.Drawing.Font("Times New Roman", 10F, System.Drawing.FontStyle.Bold);
+            this.reportDateTimeInfo.Format = "{0:dd-MM-yyyy H:mm:ss}";
+            this.reportDateTimeInfo.LocationFloat = new DevExpress.Utils.PointFloat(547.1335F, 0F);
+            this.reportDateTimeInfo.Name = "reportDateTimeInfo";
+            this.reportDateTimeInfo.Padding = new DevExpress.XtraPrinting.PaddingInfo(2, 2, 0, 0, 100F);
+            this.reportDateTimeInfo.PageInfo = DevExpress.XtraPrinting.PageInfo.DateTime;
+            this.reportDateTimeInfo.SizeF = new System.Drawing.SizeF(189.8665F, 33F);
+            this.reportDateTimeInfo.StylePriority.UseFont = false;
+            this.reportDateTimeInfo.StylePriority.UseTextAlignment = false;
+            this.reportDateTimeInfo.TextAlignment = DevExpress.XtraPrinting.TextAlignment.BottomRight;
             // 
             // xrLabel5
             // 
@@ -244,7 +259,7 @@
             this.xrLabel5.LocationFloat = new DevExpress.Utils.PointFloat(0F, 0F);
             this.xrLabel5.Name = "xrLabel5";
             this.xrLabel5.Padding = new DevExpress.XtraPrinting.PaddingInfo(2, 2, 0, 0, 100F);
-            this.xrLabel5.SizeF = new System.Drawing.SizeF(737F, 33F);
+            this.xrLabel5.SizeF = new System.Drawing.SizeF(547.1335F, 33F);
             this.xrLabel5.StyleName = "Title";
             this.xrLabel5.StylePriority.UseForeColor = false;
             this.xrLabel5.Text = "Рапорт по отгрузке ";
@@ -437,5 +452,6 @@
         private DevExpress.XtraReports.UI.XRLabel xrLabel4;
         private DevExpress.XtraReports.UI.XRLabel xrLabel3;
         private DevExpress.DataAccess.Sql.SqlDataSource sqlDataSource2;
+        private DevExpress.XtraReports.UI.XRPageInfo reportDateTimeInfo;
     }
 }

--- a/src/PrizmMainProject/Forms/Reports/Mill/LoadingXtraReport.Designer.cs
+++ b/src/PrizmMainProject/Forms/Reports/Mill/LoadingXtraReport.Designer.cs
@@ -237,29 +237,29 @@
             this.reportHeaderBand1.Controls.AddRange(new DevExpress.XtraReports.UI.XRControl[] {
             this.reportDateTimeInfo,
             this.xrLabel5});
-            this.reportHeaderBand1.HeightF = 33.29166F;
+            this.reportHeaderBand1.HeightF = 52.45833F;
             this.reportHeaderBand1.Name = "reportHeaderBand1";
             // 
             // reportDateTimeInfo
             // 
             this.reportDateTimeInfo.Font = new System.Drawing.Font("Times New Roman", 10F, System.Drawing.FontStyle.Bold);
-            this.reportDateTimeInfo.Format = "{0:dd-MM-yyyy H:mm:ss}";
-            this.reportDateTimeInfo.LocationFloat = new DevExpress.Utils.PointFloat(547.1335F, 0F);
+            this.reportDateTimeInfo.Format = "Сформирован: {0:dd-MM-yyyy H:mm:ss}";
+            this.reportDateTimeInfo.LocationFloat = new DevExpress.Utils.PointFloat(451.0906F, 0F);
             this.reportDateTimeInfo.Name = "reportDateTimeInfo";
             this.reportDateTimeInfo.Padding = new DevExpress.XtraPrinting.PaddingInfo(2, 2, 0, 0, 100F);
             this.reportDateTimeInfo.PageInfo = DevExpress.XtraPrinting.PageInfo.DateTime;
-            this.reportDateTimeInfo.SizeF = new System.Drawing.SizeF(189.8665F, 33F);
+            this.reportDateTimeInfo.SizeF = new System.Drawing.SizeF(285.9094F, 19.45833F);
             this.reportDateTimeInfo.StylePriority.UseFont = false;
             this.reportDateTimeInfo.StylePriority.UseTextAlignment = false;
-            this.reportDateTimeInfo.TextAlignment = DevExpress.XtraPrinting.TextAlignment.BottomRight;
+            this.reportDateTimeInfo.TextAlignment = DevExpress.XtraPrinting.TextAlignment.TopRight;
             // 
             // xrLabel5
             // 
             this.xrLabel5.ForeColor = System.Drawing.Color.Black;
-            this.xrLabel5.LocationFloat = new DevExpress.Utils.PointFloat(0F, 0F);
+            this.xrLabel5.LocationFloat = new DevExpress.Utils.PointFloat(0F, 19.45833F);
             this.xrLabel5.Name = "xrLabel5";
             this.xrLabel5.Padding = new DevExpress.XtraPrinting.PaddingInfo(2, 2, 0, 0, 100F);
-            this.xrLabel5.SizeF = new System.Drawing.SizeF(547.1335F, 33F);
+            this.xrLabel5.SizeF = new System.Drawing.SizeF(736.9999F, 33F);
             this.xrLabel5.StyleName = "Title";
             this.xrLabel5.StylePriority.UseForeColor = false;
             this.xrLabel5.Text = "Рапорт по отгрузке ";

--- a/src/PrizmMainProject/Forms/Reports/Mill/MillReportsXtraReport.Designer.cs
+++ b/src/PrizmMainProject/Forms/Reports/Mill/MillReportsXtraReport.Designer.cs
@@ -438,29 +438,29 @@
             this.reportHeader.Controls.AddRange(new DevExpress.XtraReports.UI.XRControl[] {
             this.reportDateTimeInfo,
             this.reportHeaderLabel});
-            this.reportHeader.HeightF = 33.29166F;
+            this.reportHeader.HeightF = 56.91666F;
             this.reportHeader.Name = "reportHeader";
             // 
             // reportDateTimeInfo
             // 
             this.reportDateTimeInfo.Font = new System.Drawing.Font("Times New Roman", 10F, System.Drawing.FontStyle.Bold);
-            this.reportDateTimeInfo.Format = "{0:dd-MM-yyyy H:mm:ss}";
-            this.reportDateTimeInfo.LocationFloat = new DevExpress.Utils.PointFloat(849.3751F, 0F);
+            this.reportDateTimeInfo.Format = "Сформирован: {0:dd-MM-yyyy H:mm:ss}";
+            this.reportDateTimeInfo.LocationFloat = new DevExpress.Utils.PointFloat(749.3335F, 0F);
             this.reportDateTimeInfo.Name = "reportDateTimeInfo";
             this.reportDateTimeInfo.Padding = new DevExpress.XtraPrinting.PaddingInfo(2, 2, 0, 0, 100F);
             this.reportDateTimeInfo.PageInfo = DevExpress.XtraPrinting.PageInfo.DateTime;
-            this.reportDateTimeInfo.SizeF = new System.Drawing.SizeF(165.6249F, 33.29166F);
+            this.reportDateTimeInfo.SizeF = new System.Drawing.SizeF(266.6665F, 23.91666F);
             this.reportDateTimeInfo.StylePriority.UseFont = false;
             this.reportDateTimeInfo.StylePriority.UseTextAlignment = false;
-            this.reportDateTimeInfo.TextAlignment = DevExpress.XtraPrinting.TextAlignment.BottomRight;
+            this.reportDateTimeInfo.TextAlignment = DevExpress.XtraPrinting.TextAlignment.TopRight;
             // 
             // reportHeaderLabel
             // 
             this.reportHeaderLabel.ForeColor = System.Drawing.Color.Black;
-            this.reportHeaderLabel.LocationFloat = new DevExpress.Utils.PointFloat(6.357829E-05F, 0F);
+            this.reportHeaderLabel.LocationFloat = new DevExpress.Utils.PointFloat(0F, 23.91666F);
             this.reportHeaderLabel.Name = "reportHeaderLabel";
             this.reportHeaderLabel.Padding = new DevExpress.XtraPrinting.PaddingInfo(2, 2, 0, 0, 100F);
-            this.reportHeaderLabel.SizeF = new System.Drawing.SizeF(849.375F, 33F);
+            this.reportHeaderLabel.SizeF = new System.Drawing.SizeF(1015F, 33F);
             this.reportHeaderLabel.StyleName = "Title";
             this.reportHeaderLabel.StylePriority.UseForeColor = false;
             this.reportHeaderLabel.Text = "Отчет на заводе";

--- a/src/PrizmMainProject/Forms/Reports/Mill/MillReportsXtraReport.Designer.cs
+++ b/src/PrizmMainProject/Forms/Reports/Mill/MillReportsXtraReport.Designer.cs
@@ -102,6 +102,7 @@
             this.datePageInfo = new DevExpress.XtraReports.UI.XRPageInfo();
             this.numberOfPageInfo = new DevExpress.XtraReports.UI.XRPageInfo();
             this.reportHeader = new DevExpress.XtraReports.UI.ReportHeaderBand();
+            this.reportDateTimeInfo = new DevExpress.XtraReports.UI.XRPageInfo();
             this.reportHeaderLabel = new DevExpress.XtraReports.UI.XRLabel();
             this.Title = new DevExpress.XtraReports.UI.XRControlStyle();
             this.FieldCaption = new DevExpress.XtraReports.UI.XRControlStyle();
@@ -435,17 +436,31 @@
             // reportHeader
             // 
             this.reportHeader.Controls.AddRange(new DevExpress.XtraReports.UI.XRControl[] {
+            this.reportDateTimeInfo,
             this.reportHeaderLabel});
             this.reportHeader.HeightF = 33.29166F;
             this.reportHeader.Name = "reportHeader";
             // 
+            // reportDateTimeInfo
+            // 
+            this.reportDateTimeInfo.Font = new System.Drawing.Font("Times New Roman", 10F, System.Drawing.FontStyle.Bold);
+            this.reportDateTimeInfo.Format = "{0:dd-MM-yyyy H:mm:ss}";
+            this.reportDateTimeInfo.LocationFloat = new DevExpress.Utils.PointFloat(849.3751F, 0F);
+            this.reportDateTimeInfo.Name = "reportDateTimeInfo";
+            this.reportDateTimeInfo.Padding = new DevExpress.XtraPrinting.PaddingInfo(2, 2, 0, 0, 100F);
+            this.reportDateTimeInfo.PageInfo = DevExpress.XtraPrinting.PageInfo.DateTime;
+            this.reportDateTimeInfo.SizeF = new System.Drawing.SizeF(165.6249F, 33.29166F);
+            this.reportDateTimeInfo.StylePriority.UseFont = false;
+            this.reportDateTimeInfo.StylePriority.UseTextAlignment = false;
+            this.reportDateTimeInfo.TextAlignment = DevExpress.XtraPrinting.TextAlignment.BottomRight;
+            // 
             // reportHeaderLabel
             // 
             this.reportHeaderLabel.ForeColor = System.Drawing.Color.Black;
-            this.reportHeaderLabel.LocationFloat = new DevExpress.Utils.PointFloat(7.549921E-05F, 0F);
+            this.reportHeaderLabel.LocationFloat = new DevExpress.Utils.PointFloat(6.357829E-05F, 0F);
             this.reportHeaderLabel.Name = "reportHeaderLabel";
             this.reportHeaderLabel.Padding = new DevExpress.XtraPrinting.PaddingInfo(2, 2, 0, 0, 100F);
-            this.reportHeaderLabel.SizeF = new System.Drawing.SizeF(1015F, 33F);
+            this.reportHeaderLabel.SizeF = new System.Drawing.SizeF(849.375F, 33F);
             this.reportHeaderLabel.StyleName = "Title";
             this.reportHeaderLabel.StylePriority.UseForeColor = false;
             this.reportHeaderLabel.Text = "Отчет на заводе";
@@ -744,5 +759,6 @@
         private DevExpress.XtraReports.Parameters.Parameter StatusParameter;
         private DevExpress.XtraReports.UI.CalculatedField calculatedField1;
         private DevExpress.XtraReports.UI.XRLabel xrLabel1;
+        private DevExpress.XtraReports.UI.XRPageInfo reportDateTimeInfo;
     }
 }

--- a/src/PrizmMainProject/Forms/Reports/Mill/additionToTheReport.Designer.cs
+++ b/src/PrizmMainProject/Forms/Reports/Mill/additionToTheReport.Designer.cs
@@ -49,6 +49,7 @@
             this.xrPageInfo2 = new DevExpress.XtraReports.UI.XRPageInfo();
             this.reportHeaderBand1 = new DevExpress.XtraReports.UI.ReportHeaderBand();
             this.xrLabel11 = new DevExpress.XtraReports.UI.XRLabel();
+            this.reportDateTimeInfo = new DevExpress.XtraReports.UI.XRPageInfo();
             this.Title = new DevExpress.XtraReports.UI.XRControlStyle();
             this.FieldCaption = new DevExpress.XtraReports.UI.XRControlStyle();
             this.PageInfo = new DevExpress.XtraReports.UI.XRControlStyle();
@@ -131,7 +132,7 @@
             // 
             // TopMargin
             // 
-            this.TopMargin.HeightF = 49F;
+            this.TopMargin.HeightF = 49.00001F;
             this.TopMargin.Name = "TopMargin";
             this.TopMargin.Padding = new DevExpress.XtraPrinting.PaddingInfo(0, 0, 0, 0, 100F);
             this.TopMargin.TextAlignment = DevExpress.XtraPrinting.TextAlignment.TopLeft;
@@ -229,7 +230,8 @@
             // reportHeaderBand1
             // 
             this.reportHeaderBand1.Controls.AddRange(new DevExpress.XtraReports.UI.XRControl[] {
-            this.xrLabel11});
+            this.xrLabel11,
+            this.reportDateTimeInfo});
             this.reportHeaderBand1.HeightF = 33.29166F;
             this.reportHeaderBand1.Name = "reportHeaderBand1";
             // 
@@ -238,9 +240,22 @@
             this.xrLabel11.LocationFloat = new DevExpress.Utils.PointFloat(0.9401321F, 0F);
             this.xrLabel11.Name = "xrLabel11";
             this.xrLabel11.Padding = new DevExpress.XtraPrinting.PaddingInfo(2, 2, 0, 0, 100F);
-            this.xrLabel11.SizeF = new System.Drawing.SizeF(659.7264F, 33F);
+            this.xrLabel11.SizeF = new System.Drawing.SizeF(514.2477F, 33F);
             this.xrLabel11.StyleName = "Title";
             this.xrLabel11.Text = "Приложение к отчету";
+            // 
+            // reportDateTimeInfo
+            // 
+            this.reportDateTimeInfo.Font = new System.Drawing.Font("Times New Roman", 10F, System.Drawing.FontStyle.Bold);
+            this.reportDateTimeInfo.Format = "{0:dd-MM-yyyy H:mm:ss}";
+            this.reportDateTimeInfo.LocationFloat = new DevExpress.Utils.PointFloat(515.8614F, 0F);
+            this.reportDateTimeInfo.Name = "reportDateTimeInfo";
+            this.reportDateTimeInfo.Padding = new DevExpress.XtraPrinting.PaddingInfo(2, 2, 0, 0, 100F);
+            this.reportDateTimeInfo.PageInfo = DevExpress.XtraPrinting.PageInfo.DateTime;
+            this.reportDateTimeInfo.SizeF = new System.Drawing.SizeF(144.8051F, 33F);
+            this.reportDateTimeInfo.StylePriority.UseFont = false;
+            this.reportDateTimeInfo.StylePriority.UseTextAlignment = false;
+            this.reportDateTimeInfo.TextAlignment = DevExpress.XtraPrinting.TextAlignment.BottomRight;
             // 
             // Title
             // 
@@ -430,5 +445,6 @@
         private DevExpress.XtraReports.UI.XRLabel totalCount;
         private DevExpress.XtraReports.UI.XRLabel pipesWeight;
         private DevExpress.XtraReports.UI.XRLabel pipesLength;
+        private DevExpress.XtraReports.UI.XRPageInfo reportDateTimeInfo;
     }
 }

--- a/src/PrizmMainProject/Forms/Reports/Mill/additionToTheReport.Designer.cs
+++ b/src/PrizmMainProject/Forms/Reports/Mill/additionToTheReport.Designer.cs
@@ -232,30 +232,30 @@
             this.reportHeaderBand1.Controls.AddRange(new DevExpress.XtraReports.UI.XRControl[] {
             this.xrLabel11,
             this.reportDateTimeInfo});
-            this.reportHeaderBand1.HeightF = 33.29166F;
+            this.reportHeaderBand1.HeightF = 50.375F;
             this.reportHeaderBand1.Name = "reportHeaderBand1";
             // 
             // xrLabel11
             // 
-            this.xrLabel11.LocationFloat = new DevExpress.Utils.PointFloat(0.9401321F, 0F);
+            this.xrLabel11.LocationFloat = new DevExpress.Utils.PointFloat(0F, 17.37501F);
             this.xrLabel11.Name = "xrLabel11";
             this.xrLabel11.Padding = new DevExpress.XtraPrinting.PaddingInfo(2, 2, 0, 0, 100F);
-            this.xrLabel11.SizeF = new System.Drawing.SizeF(514.2477F, 33F);
+            this.xrLabel11.SizeF = new System.Drawing.SizeF(663.0001F, 33F);
             this.xrLabel11.StyleName = "Title";
             this.xrLabel11.Text = "Приложение к отчету";
             // 
             // reportDateTimeInfo
             // 
             this.reportDateTimeInfo.Font = new System.Drawing.Font("Times New Roman", 10F, System.Drawing.FontStyle.Bold);
-            this.reportDateTimeInfo.Format = "{0:dd-MM-yyyy H:mm:ss}";
-            this.reportDateTimeInfo.LocationFloat = new DevExpress.Utils.PointFloat(515.8614F, 0F);
+            this.reportDateTimeInfo.Format = "Сформирован: {0:dd-MM-yyyy H:mm:ss}";
+            this.reportDateTimeInfo.LocationFloat = new DevExpress.Utils.PointFloat(400.2364F, 0F);
             this.reportDateTimeInfo.Name = "reportDateTimeInfo";
             this.reportDateTimeInfo.Padding = new DevExpress.XtraPrinting.PaddingInfo(2, 2, 0, 0, 100F);
             this.reportDateTimeInfo.PageInfo = DevExpress.XtraPrinting.PageInfo.DateTime;
-            this.reportDateTimeInfo.SizeF = new System.Drawing.SizeF(144.8051F, 33F);
+            this.reportDateTimeInfo.SizeF = new System.Drawing.SizeF(262.7637F, 17.375F);
             this.reportDateTimeInfo.StylePriority.UseFont = false;
             this.reportDateTimeInfo.StylePriority.UseTextAlignment = false;
-            this.reportDateTimeInfo.TextAlignment = DevExpress.XtraPrinting.TextAlignment.BottomRight;
+            this.reportDateTimeInfo.TextAlignment = DevExpress.XtraPrinting.TextAlignment.TopRight;
             // 
             // Title
             // 


### PR DESCRIPTION
PRISM-86 Все отчеты должны включать в себя информацию о дате и времени создания.
