### PR TITLE
Incoming inspection dialog validation #PRISM-114 Fixed

### DIFF
--- a/src/PrizmMainProject/Forms/Parts/Inspection/PartInspectionXtraForm.Designer.cs
+++ b/src/PrizmMainProject/Forms/Parts/Inspection/PartInspectionXtraForm.Designer.cs
@@ -163,6 +163,7 @@
             this.inspectionsView.InitNewRow += new DevExpress.XtraGrid.Views.Grid.InitNewRowEventHandler(this.inspectionsView_InitNewRow);
             this.inspectionsView.ValidateRow += new DevExpress.XtraGrid.Views.Base.ValidateRowEventHandler(this.inspectionsView_ValidateRow);
             this.inspectionsView.KeyDown += new System.Windows.Forms.KeyEventHandler(this.inspectionsView_KeyDown);
+            this.inspectionsView.InvalidRowException += new DevExpress.XtraGrid.Views.Base.InvalidRowExceptionEventHandler(this.HandleInvalidRowException);
             // 
             // colDate
             // 

--- a/src/PrizmMainProject/Forms/Parts/Inspection/PartInspectionXtraForm.cs
+++ b/src/PrizmMainProject/Forms/Parts/Inspection/PartInspectionXtraForm.cs
@@ -18,6 +18,7 @@ using DevExpress.XtraGrid.Views.Grid;
 using Prizm.Main.Languages;
 using Prizm.Main.Documents;
 using Prizm.Main.Common;
+using DevExpress.XtraGrid.Views.Base;
 
 namespace Prizm.Main.Forms.Parts.Inspection
 {
@@ -276,6 +277,11 @@ namespace Prizm.Main.Forms.Parts.Inspection
             }
 
             view.RefreshData();
+        }
+
+        private void HandleInvalidRowException(object sender, InvalidRowExceptionEventArgs e)
+        {
+            e.ExceptionMode = DevExpress.XtraEditors.Controls.ExceptionMode.NoAction;
         }
 
     }

--- a/src/PrizmMainProject/Properties/Resources.Designer.cs
+++ b/src/PrizmMainProject/Properties/Resources.Designer.cs
@@ -3951,6 +3951,15 @@ namespace Prizm.Main.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Значение обязательно.
+        /// </summary>
+        internal static string Value_Required {
+            get {
+                return ResourceManager.GetString("Value_Required", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Ожидайте.
         /// </summary>
         internal static string WaitScreen_Caption {

--- a/src/PrizmMainProject/Properties/Resources.resx
+++ b/src/PrizmMainProject/Properties/Resources.resx
@@ -1467,4 +1467,7 @@
   <data name="Joint_JointTestResultStatus_Withdraw" xml:space="preserve">
     <value>Вырезка</value>
   </data>
+  <data name="Value_Required" xml:space="preserve">
+    <value>Значение обязательно</value>
+  </data>
 </root>


### PR DESCRIPTION
Fixed displaying validation dialog
Also added missing translation
Issue:
# PRISM-114 при вводе результатов или выборе инспектора любое нажатие

клавиатуру приводит к сообщению Error. Do you want to correct value?
