### PR TITLE
Spool, component validation #PRISM-114 Fixed

### DIFF
--- a/src/PrizmMainProject/Forms/Component/NewEdit/ComponentNewEditXtraForm.Designer.cs
+++ b/src/PrizmMainProject/Forms/Component/NewEdit/ComponentNewEditXtraForm.Designer.cs
@@ -244,6 +244,7 @@
             this.inspectionHistoryGridView.CellValueChanged += new DevExpress.XtraGrid.Views.Base.CellValueChangedEventHandler(this.CellModifiedGridView_CellValueChanged);
             this.inspectionHistoryGridView.ValidateRow += new DevExpress.XtraGrid.Views.Base.ValidateRowEventHandler(this.inspectionHistoryGridView_ValidateRow);
             this.inspectionHistoryGridView.KeyDown += new System.Windows.Forms.KeyEventHandler(this.inspectionHistoryGridView_KeyDown);
+            this.inspectionHistoryGridView.InvalidRowException += new DevExpress.XtraGrid.Views.Base.InvalidRowExceptionEventHandler(this.HandleInvalidRowException);
             // 
             // inspectionDateColumn
             // 

--- a/src/PrizmMainProject/Forms/Component/NewEdit/ComponentNewEditXtraForm.cs
+++ b/src/PrizmMainProject/Forms/Component/NewEdit/ComponentNewEditXtraForm.cs
@@ -424,5 +424,10 @@ namespace Prizm.Main.Forms.Component.NewEdit
                 ValidateInspection(inspectionHistoryGridView, inspectorColumn.Name.ToString(), e);
             }
         }
+
+        private void HandleInvalidRowException(object sender, InvalidRowExceptionEventArgs e)
+        {
+            e.ExceptionMode = DevExpress.XtraEditors.Controls.ExceptionMode.NoAction;
+        }
     }
 }

--- a/src/PrizmMainProject/Forms/Spool/SpoolsXtraForm.Designer.cs
+++ b/src/PrizmMainProject/Forms/Spool/SpoolsXtraForm.Designer.cs
@@ -204,6 +204,7 @@
             this.inspectionHistoryGridView.InitNewRow += new DevExpress.XtraGrid.Views.Grid.InitNewRowEventHandler(this.inspectionHistoryGridView_InitNewRow);
             this.inspectionHistoryGridView.ValidateRow += new DevExpress.XtraGrid.Views.Base.ValidateRowEventHandler(this.inspectionHistoryGridView_ValidateRow);
             this.inspectionHistoryGridView.KeyDown += new System.Windows.Forms.KeyEventHandler(this.inspectionHistoryGridView_KeyDown);
+            this.inspectionHistoryGridView.InvalidRowException += new DevExpress.XtraGrid.Views.Base.InvalidRowExceptionEventHandler(this.HandleInvalidRowException);
             // 
             // inspectionDateGridColumn
             // 

--- a/src/PrizmMainProject/Forms/Spool/SpoolsXtraForm.cs
+++ b/src/PrizmMainProject/Forms/Spool/SpoolsXtraForm.cs
@@ -364,5 +364,10 @@ namespace Prizm.Main.Forms.Spool
 
             view.RefreshData();
         }
+
+        private void HandleInvalidRowException(object sender, InvalidRowExceptionEventArgs e)
+        {
+            e.ExceptionMode = DevExpress.XtraEditors.Controls.ExceptionMode.NoAction;
+        }
     }
 }


### PR DESCRIPTION
Disabled dialog showing on Spools and Component form
Issue:
# PRISM-114 при вводе результатов или выборе инспектора любое нажатие

клавиатуру приводит к сообщению Error. Do you want to correct value?
