### PR TITLE
add clear() before loading localizedPartTypes #PRISM-112 Fixed

### DIFF
--- a/src/PrizmMainProject/Forms/Parts/Inspection/InspectionSelectPartDialog.cs
+++ b/src/PrizmMainProject/Forms/Parts/Inspection/InspectionSelectPartDialog.cs
@@ -35,6 +35,7 @@ namespace Prizm.Main.Forms.Parts.Inspection
         }
         private void NumbersDialog_Load(object sender, EventArgs e)
         {
+            localizedPartTypes.Clear();
             foreach (var item in EnumWrapper<PartType>.EnumerateItems(skip0: true))
             {
                 localizedPartTypes.Add(item.Item2);


### PR DESCRIPTION
PRISM-112 После входного контроля 8990 труб программа имеет 126 375 handles (дескрипторов), свеже запущенная - всего 375-390
