### PR TITLE
Order column in inspections grid must be readonly #PRISM-124 Fixed

### DIFF
--- a/src/PrizmMainProject/Forms/Component/NewEdit/ComponentNewEditXtraForm.Designer.cs
+++ b/src/PrizmMainProject/Forms/Component/NewEdit/ComponentNewEditXtraForm.Designer.cs
@@ -242,9 +242,9 @@
             new DevExpress.XtraGrid.Columns.GridColumnSortInfo(this.orderColumn, DevExpress.Data.ColumnSortOrder.Ascending)});
             this.inspectionHistoryGridView.InitNewRow += new DevExpress.XtraGrid.Views.Grid.InitNewRowEventHandler(this.inspectionHistoryGridView_InitNewRow);
             this.inspectionHistoryGridView.CellValueChanged += new DevExpress.XtraGrid.Views.Base.CellValueChangedEventHandler(this.CellModifiedGridView_CellValueChanged);
+            this.inspectionHistoryGridView.InvalidRowException += new DevExpress.XtraGrid.Views.Base.InvalidRowExceptionEventHandler(this.HandleInvalidRowException);
             this.inspectionHistoryGridView.ValidateRow += new DevExpress.XtraGrid.Views.Base.ValidateRowEventHandler(this.inspectionHistoryGridView_ValidateRow);
             this.inspectionHistoryGridView.KeyDown += new System.Windows.Forms.KeyEventHandler(this.inspectionHistoryGridView_KeyDown);
-            this.inspectionHistoryGridView.InvalidRowException += new DevExpress.XtraGrid.Views.Base.InvalidRowExceptionEventHandler(this.HandleInvalidRowException);
             // 
             // inspectionDateColumn
             // 
@@ -323,6 +323,8 @@
             this.orderColumn.Caption = "Порядок";
             this.orderColumn.FieldName = "Order";
             this.orderColumn.Name = "orderColumn";
+            this.orderColumn.OptionsColumn.AllowEdit = false;
+            this.orderColumn.OptionsColumn.ReadOnly = true;
             this.orderColumn.Visible = true;
             this.orderColumn.VisibleIndex = 4;
             this.orderColumn.Width = 50;

--- a/src/PrizmMainProject/Forms/Parts/Inspection/PartInspectionXtraForm.Designer.cs
+++ b/src/PrizmMainProject/Forms/Parts/Inspection/PartInspectionXtraForm.Designer.cs
@@ -238,6 +238,8 @@
             this.colOrder.Caption = "Порядок";
             this.colOrder.FieldName = "Order";
             this.colOrder.Name = "colOrder";
+            this.colOrder.OptionsColumn.AllowEdit = false;
+            this.colOrder.OptionsColumn.ReadOnly = true;
             this.colOrder.Visible = true;
             this.colOrder.VisibleIndex = 4;
             // 

--- a/src/PrizmMainProject/Forms/Spool/SpoolsXtraForm.Designer.cs
+++ b/src/PrizmMainProject/Forms/Spool/SpoolsXtraForm.Designer.cs
@@ -202,9 +202,9 @@
             this.inspectionHistoryGridView.SortInfo.AddRange(new DevExpress.XtraGrid.Columns.GridColumnSortInfo[] {
             new DevExpress.XtraGrid.Columns.GridColumnSortInfo(this.orderGridColumn, DevExpress.Data.ColumnSortOrder.Ascending)});
             this.inspectionHistoryGridView.InitNewRow += new DevExpress.XtraGrid.Views.Grid.InitNewRowEventHandler(this.inspectionHistoryGridView_InitNewRow);
+            this.inspectionHistoryGridView.InvalidRowException += new DevExpress.XtraGrid.Views.Base.InvalidRowExceptionEventHandler(this.HandleInvalidRowException);
             this.inspectionHistoryGridView.ValidateRow += new DevExpress.XtraGrid.Views.Base.ValidateRowEventHandler(this.inspectionHistoryGridView_ValidateRow);
             this.inspectionHistoryGridView.KeyDown += new System.Windows.Forms.KeyEventHandler(this.inspectionHistoryGridView_KeyDown);
-            this.inspectionHistoryGridView.InvalidRowException += new DevExpress.XtraGrid.Views.Base.InvalidRowExceptionEventHandler(this.HandleInvalidRowException);
             // 
             // inspectionDateGridColumn
             // 
@@ -283,6 +283,8 @@
             this.orderGridColumn.Caption = "Порядок";
             this.orderGridColumn.FieldName = "Order";
             this.orderGridColumn.Name = "orderGridColumn";
+            this.orderGridColumn.OptionsColumn.AllowEdit = false;
+            this.orderGridColumn.OptionsColumn.ReadOnly = true;
             this.orderGridColumn.Visible = true;
             this.orderGridColumn.VisibleIndex = 4;
             // 


### PR DESCRIPTION
make orderColumn read only
