### PR TITLE
Audit: added column with operation type #PRISM-99 Fixed

### DIFF
--- a/src/Data/DAL/Hibernate/AuditLogRepository.cs
+++ b/src/Data/DAL/Hibernate/AuditLogRepository.cs
@@ -163,9 +163,9 @@ namespace Prizm.Data.DAL.Hibernate
                 User = (Guid)tuple[3],
                 TableName = (ItemTypes)tuple[4],
                 FieldName = (FieldNames)tuple[5],
-                OldValue = (tuple[6] == null) ? ((HibernateUtil.Import) ? "imported" : "created" ): tuple[6].ToString(),
-                NewValue = (tuple[7] == null) ? "deleted" : tuple[7].ToString(),
-                Number = (tuple[10] == null) ? "" : tuple[10].ToString(),
+                OldValue = (tuple[6] == null) ? String.Empty : tuple[6].ToString(),
+                NewValue = (tuple[7] == null) ? String.Empty : tuple[7].ToString(),
+                Number = (tuple[10] == null) ? String.Empty : tuple[10].ToString(),
                 UserName = Users.Where(_ => _.Id == (Guid)tuple[3]).SingleOrDefault().Name.GetFullName(),
                 OwnerId = (tuple[8]==null) ? Guid.Empty : (Guid)tuple[8],
                 OperationType = (AuditRecordType)Enum.Parse(typeof(AuditRecordType), tuple[9].ToString())

--- a/src/PrizmMainProject/Forms/Audit/AuditXtraForm.Designer.cs
+++ b/src/PrizmMainProject/Forms/Audit/AuditXtraForm.Designer.cs
@@ -45,6 +45,7 @@
             this.newValueGridColumn = new DevExpress.XtraGrid.Columns.GridColumn();
             this.fieldGridColumn = new DevExpress.XtraGrid.Columns.GridColumn();
             this.numberColumn = new DevExpress.XtraGrid.Columns.GridColumn();
+            this.operationTypeColumn = new DevExpress.XtraGrid.Columns.GridColumn();
             this.endDate = new DevExpress.XtraEditors.DateEdit();
             this.startDate = new DevExpress.XtraEditors.DateEdit();
             this.generalAuditLayoutGroup = new DevExpress.XtraLayout.LayoutControlGroup();
@@ -196,7 +197,8 @@
             this.oldValueGridColumn,
             this.newValueGridColumn,
             this.fieldGridColumn,
-            this.numberColumn});
+            this.numberColumn,
+            this.operationTypeColumn});
             this.auditResultsView.GridControl = this.auditResults;
             this.auditResultsView.GroupCount = 2;
             this.auditResultsView.Name = "auditResultsView";
@@ -273,6 +275,14 @@
             this.numberColumn.Name = "numberColumn";
             this.numberColumn.Visible = true;
             this.numberColumn.VisibleIndex = 4;
+            // 
+            // operationTypeColumn
+            // 
+            this.operationTypeColumn.Caption = "Тип записи";
+            this.operationTypeColumn.FieldName = "OperationType";
+            this.operationTypeColumn.Name = "operationTypeColumn";
+            this.operationTypeColumn.Visible = true;
+            this.operationTypeColumn.VisibleIndex = 5;
             // 
             // endDate
             // 
@@ -589,5 +599,6 @@
         private DevExpress.XtraLayout.EmptySpaceItem emptySpaceItem4;
         private DevExpress.XtraEditors.CheckedListBoxControl includeCheckedList;
         private DevExpress.XtraLayout.LayoutControlItem includeCheckedListLayout;
+        private DevExpress.XtraGrid.Columns.GridColumn operationTypeColumn;
     }
 }

--- a/src/PrizmMainProject/Forms/Audit/AuditXtraForm.cs
+++ b/src/PrizmMainProject/Forms/Audit/AuditXtraForm.cs
@@ -23,6 +23,7 @@ namespace Prizm.Main.Forms.Audit
     {
         private AuditViewModel viewModel;
         private ICommandManager commandManager = new CommandManager();
+        private static readonly log4net.ILog log = log4net.LogManager.GetLogger(typeof(AuditXtraForm));
 
         public AuditXtraForm()
         {
@@ -162,6 +163,7 @@ namespace Prizm.Main.Forms.Audit
                     case "D": e.DisplayText = Program.LanguageManager.GetString(StringResources.Audit_CheckDeleted);
                         break;
                     default: e.DisplayText = String.Empty;
+                        log.Warn(string.Format("String resource for {O} audit operation type is missing", e.Value.ToString()));
                         break;
                 }
             }

--- a/src/PrizmMainProject/Forms/Audit/AuditXtraForm.cs
+++ b/src/PrizmMainProject/Forms/Audit/AuditXtraForm.cs
@@ -90,6 +90,7 @@ namespace Prizm.Main.Forms.Audit
                     new LocalizedItem(newValueGridColumn, StringResources.Audit_NewValueColumnHeader.Id),
                     new LocalizedItem(fieldGridColumn, StringResources.Audit_FieldColumnHeader.Id),
                     new LocalizedItem(numberColumn, StringResources.Audit_NumberColumnHeader.Id),
+                    new LocalizedItem(operationTypeColumn, StringResources.Audit_OperationTypeColumnHeader.Id),
 
                     // layout control groups
                     new LocalizedItem(searchParametersLayoutGroup, StringResources.Audit_SearchParametersGroup.Id),
@@ -147,7 +148,22 @@ namespace Prizm.Main.Forms.Audit
                 {
                     e.DisplayText = Program.LanguageManager.GetString((StringResource)resId);
                 }
-
+            }
+            if (e.Column.Name.Equals(operationTypeColumn.Name))
+            {
+                switch (e.Value.ToString())
+                {
+                    case "E": e.DisplayText = Program.LanguageManager.GetString(StringResources.Audit_CheckEdited);
+                        break;
+                    case "I": e.DisplayText = Program.LanguageManager.GetString(StringResources.Audit_CheckImported);
+                        break;
+                    case "C": e.DisplayText = Program.LanguageManager.GetString(StringResources.Audit_CheckCreated);
+                        break;
+                    case "D": e.DisplayText = Program.LanguageManager.GetString(StringResources.Audit_CheckDeleted);
+                        break;
+                    default: e.DisplayText = String.Empty;
+                        break;
+                }
             }
         }
 

--- a/src/PrizmMainProject/Languages/LocalizedStrings/Strings.en-US.txt
+++ b/src/PrizmMainProject/Languages/LocalizedStrings/Strings.en-US.txt
@@ -877,6 +877,9 @@ Audit_NumberColumnHeader=Owner number
 ;Аудит. Надпись панели параметров поиска
 Audit_SearchParametersGroup=Search parameters
 
+;Аудит. Надпись колонки типа операции
+Audit_OperationTypeColumnHeader=Operation type
+
 ;Аудит. Надпись радиокнопки периода
 Audit_RadioPeriod=Number
 

--- a/src/PrizmMainProject/Languages/StringResources.cs
+++ b/src/PrizmMainProject/Languages/StringResources.cs
@@ -2161,6 +2161,12 @@ namespace Prizm.Main.Languages
             Id = "Audit_NumberColumnHeader", 
             Description = "Аудит. Надпись колонки номера"};
 
+        public static StringResource Audit_OperationTypeColumnHeader = new StringResource
+        {
+            Id = "Audit_OperationTypeColumnHeader",
+            Description = "Аудит. Надпись колонки типа операции"
+        };
+
         public static StringResource Audit_SearchParametersGroup = new StringResource { 
             Id = "Audit_SearchParametersGroup", 
             Description = "Аудит. Надпись панели параметров поиска"};


### PR DESCRIPTION
Added column with operation type. Added event to get translation for operation type

Issue:
# PRISM-99 We should be able to filter information by "imported"-"deleted"-"created". fileName logging.
