### PR TITLE
 Save duplicate code of inspection operation  #PRISM-136 Fixed

### DIFF
--- a/src/PrizmMainProject/Forms/Settings/Inspections/MillInspectionXtraForm.cs
+++ b/src/PrizmMainProject/Forms/Settings/Inspections/MillInspectionXtraForm.cs
@@ -238,7 +238,7 @@ namespace Prizm.Main.Forms.Settings.Inspections
         private bool ValidateCode(string code)
         {
             var testList = pipeTestList.Where(g => g.Code==code).ToList();
-            return !(testList.Count >= 2);
+            return !(testList.Count >= 1);
         }
     }
 }


### PR DESCRIPTION
Fixed wrong logic
Issue:
# PRISM-136 Still can save duplicate code of inspection operation
