### PR TITLE
Sort available active tests #PRISM-161 Fixed

### DIFF
--- a/src/PrizmMainProject/Forms/PipeMill/NewEdit/Inspections/InspectionAddEditViewModel.cs
+++ b/src/PrizmMainProject/Forms/PipeMill/NewEdit/Inspections/InspectionAddEditViewModel.cs
@@ -44,7 +44,7 @@ namespace Prizm.Main.Forms.PipeMill.NewEdit.Inspections
             PipeTestResult current, 
             IList<EnumWrapper<PipeTestResultStatus>> statuses)
         {
-            this.availableTests = tests;
+            this.availableTests = tests.Where(_ => _.IsActive).OrderBy(_ => _.Code).ToList<PipeTest>();
             this.inspectors = inspectors;
             this.statuses = statuses;
             if (current == null)


### PR DESCRIPTION
Added sorting and isActive restriction
Issue:
# PRISM-161 сортировка номеров доступных контрольных операций в диалоге
