### PR TITLE
Percent of selective operations should always start from 1 #PRISM-151 Fixed

### DIFF
--- a/src/DatabaseMigrator/Migrations/M20150326_AddFrequency.cs
+++ b/src/DatabaseMigrator/Migrations/M20150326_AddFrequency.cs
@@ -12,7 +12,7 @@ namespace Prizm.DatabaseMigrator.Migrations
     {
         public override void Up()
         {
-            Alter.Table("PipeTest").AddColumn("frequencyType").AsString(1).Nullable().AddColumn("selectivePercent").AsInt32().Nullable();
+            Alter.Table("PipeTest").AddColumn("frequencyType").AsString(1).Nullable().AddColumn("selectivePercent").AsInt32().WithDefaultValue(1);
             Execute.Sql(@"UPDATE [PipeTest] SET frequencyType = 'R' WHERE isRequired = 1
                           UPDATE [PipeTest] SET frequencyType = 'U' WHERE isRequired = 0");
             Delete.Column("isRequired").FromTable("PipeTest");

--- a/src/Domain/Entity/Setup/PipeTest.cs
+++ b/src/Domain/Entity/Setup/PipeTest.cs
@@ -45,6 +45,7 @@ namespace Prizm.Domain.Entity.Setup
             this.PipeTestResults = new List<PipeTestResult>();
             this.RepeatedInspections = new List<PipeTest>();
             this.IsReadyToUse = false;
+            this.SelectivePercent = 1;
 
         }
 

--- a/src/PrizmMainProject/Forms/Settings/Inspections/MillInspectionViewModel.cs
+++ b/src/PrizmMainProject/Forms/Settings/Inspections/MillInspectionViewModel.cs
@@ -251,7 +251,7 @@ namespace Prizm.Main.Forms.Settings.Inspections
 
         public int SelectivePercent
         {
-            get { return pipeTest.SelectivePercent; }
+            get { return pipeTest.SelectivePercent == 0 ? 1 : pipeTest.SelectivePercent; }
             set
             {
                 if (value != pipeTest.SelectivePercent)

--- a/src/PrizmMainProject/Forms/Settings/Inspections/MillInspectionViewModel.cs
+++ b/src/PrizmMainProject/Forms/Settings/Inspections/MillInspectionViewModel.cs
@@ -251,7 +251,7 @@ namespace Prizm.Main.Forms.Settings.Inspections
 
         public int SelectivePercent
         {
-            get { return pipeTest.SelectivePercent == 0 ? 1 : pipeTest.SelectivePercent; }
+            get { return pipeTest.SelectivePercent;  }
             set
             {
                 if (value != pipeTest.SelectivePercent)


### PR DESCRIPTION
Issue:
# PRISM-151 Redesign the appearance of Inspection operation dialog in Settings
