### PR TITLE
Inspection code duplicate on new size type #PRISM-191 Fixed

### DIFF
--- a/src/PrizmMainProject/Forms/Settings/Inspections/MillInspectionXtraForm.cs
+++ b/src/PrizmMainProject/Forms/Settings/Inspections/MillInspectionXtraForm.cs
@@ -25,11 +25,12 @@ namespace Prizm.Main.Forms.Settings.Inspections
     {
         public MillInspectionViewModel viewModel;
         IReadOnlyList<PipeTest> pipeTestList;
+        IReadOnlyList<string> usedCodes;
 
-        public MillInspectionXtraForm(PipeTest current, BindingList<Category> categoryTypes, IReadOnlyList<PipeTest> pipeTestList)
+        public MillInspectionXtraForm(PipeTest current, BindingList<Category> categoryTypes, IReadOnlyList<PipeTest> pipeTestList, IReadOnlyList<string> usedCodes)
         {
             InitializeComponent();
-            this.SetupForm(current, categoryTypes, pipeTestList);
+            this.SetupForm(current, categoryTypes, pipeTestList, usedCodes);
         }
 
         private MillInspectionViewModel GetInspectionViewModel(PipeTest current, BindingList<Category> categoryTypes)
@@ -45,9 +46,10 @@ namespace Prizm.Main.Forms.Settings.Inspections
 
             return viewModel;
         }
-        public void SetupForm(PipeTest current, BindingList<Category> categoryTypes, IReadOnlyList<PipeTest> pipeTestList)
+        public void SetupForm(PipeTest current, BindingList<Category> categoryTypes, IReadOnlyList<PipeTest> pipeTestList, IReadOnlyList<string> usedCodes)
         {
             this.pipeTestList = pipeTestList;
+            this.usedCodes = usedCodes;
             viewModel = this.GetInspectionViewModel(current, categoryTypes);
             SetControlsTextLength();
             ChangeExpected();
@@ -246,7 +248,7 @@ namespace Prizm.Main.Forms.Settings.Inspections
         bool IValidatable.Validate()
         {
             bool validated = true;
-            if (pipeTestList.Where(g => g.Code == viewModel.Code && g.Id != viewModel.PipeTest.Id).Count() >= 1)
+            if ((usedCodes.Where(g => g == viewModel.Code ).Count() >= 1))
             {
                 string msg = string.Concat(Program.LanguageManager.GetString(StringResources.Inspection_ExistingCodeError), viewModel.Code);
                 string header = Program.LanguageManager.GetString(StringResources.Inspection_ExistingCodeErrorHeader);

--- a/src/PrizmMainProject/Forms/Settings/Inspections/MillInspectionXtraForm.cs
+++ b/src/PrizmMainProject/Forms/Settings/Inspections/MillInspectionXtraForm.cs
@@ -248,7 +248,7 @@ namespace Prizm.Main.Forms.Settings.Inspections
         bool IValidatable.Validate()
         {
             bool validated = true;
-            if ((usedCodes.Where(g => g == viewModel.Code ).Count() >= 1))
+            if (usedCodes.Where(g => g == viewModel.Code ).Count() >= 1)
             {
                 string msg = string.Concat(Program.LanguageManager.GetString(StringResources.Inspection_ExistingCodeError), viewModel.Code);
                 string header = Program.LanguageManager.GetString(StringResources.Inspection_ExistingCodeErrorHeader);

--- a/src/PrizmMainProject/Forms/Settings/SettingsXtraForm.cs
+++ b/src/PrizmMainProject/Forms/Settings/SettingsXtraForm.cs
@@ -1447,15 +1447,15 @@ namespace Prizm.Main.Forms.Settings
         }
 
         private MillInspectionXtraForm GetInspectionForm(PipeTest selectedTest,
-                 BindingList<Prizm.Domain.Entity.Mill.Category> categoryTypes)
+                 BindingList<Prizm.Domain.Entity.Mill.Category> categoryTypes, List<string> usedCodes)
         {
             if (inspectionForm == null)
             {
-                inspectionForm = new MillInspectionXtraForm(selectedTest, categoryTypes, viewModel.PipeTests);
+                inspectionForm = new MillInspectionXtraForm(selectedTest, categoryTypes, viewModel.PipeTests, usedCodes);
             }
             else
             {
-                inspectionForm.SetupForm(selectedTest, categoryTypes, viewModel.PipeTests);
+                inspectionForm.SetupForm(selectedTest, categoryTypes, viewModel.PipeTests, usedCodes);
             }
 
             return inspectionForm;
@@ -1466,7 +1466,7 @@ namespace Prizm.Main.Forms.Settings
         {
             if (IsEditMode && IsEditable(IsEditMode))
             {
-                var inspectionForm = GetInspectionForm(null, viewModel.CategoryTypes);
+                var inspectionForm = GetInspectionForm(null, viewModel.CategoryTypes, viewModel.PipeTests.Select(_ => _.Code).ToList<string>());
                 inspectionForm.viewModel.PipeTest.pipeType = viewModel.CurrentPipeMillSizeType;
 
                 if (inspectionForm.ShowDialog() == System.Windows.Forms.DialogResult.OK)
@@ -1487,7 +1487,7 @@ namespace Prizm.Main.Forms.Settings
                 var selectedTest = inspectionView.GetRow(inspectionView.FocusedRowHandle) as PipeTest;
                 if (selectedTest != null)
                 {
-                    var inspectionForm = GetInspectionForm(selectedTest, viewModel.CategoryTypes);
+                    var inspectionForm = GetInspectionForm(selectedTest, viewModel.CategoryTypes, viewModel.PipeTests.Where(_ => _.Code != selectedTest.Code).Select(_ => _.Code).ToList<string>());
 
                     if (inspectionForm.ShowDialog() == System.Windows.Forms.DialogResult.OK)
                     {


### PR DESCRIPTION
Added extra parameter with list of already used codes to prevent duplicates
Issue:
# PRISM-191 New inspection operations can be saved with duplicate codes
