### PR TITLE
refresh fields at reopening #PRISM-203 Fixed

### DIFF
--- a/src/PrizmMainProject/Forms/PipeMill/NewEdit/Inspections/InspectionAddEditViewModel.cs
+++ b/src/PrizmMainProject/Forms/PipeMill/NewEdit/Inspections/InspectionAddEditViewModel.cs
@@ -55,6 +55,8 @@ namespace Prizm.Main.Forms.PipeMill.NewEdit.Inspections
                 this.status = TestResult.Status;
                 this.factBool = false;
                 this.date = DateTime.Now;
+                this.factLimit = string.Empty;
+                this.factString = null;
 
                 if (this.availableTests != null && this.availableTests.Count > 0)
                     TestResult.Operation = this.availableTests[0];


### PR DESCRIPTION
PRISM-203 Old value of factual numeric field under adding new control operation at new pipe
