### PR TITLE
fix saving workstation name at FirstSetupSaveCommand execution #PRISM-79

### DIFF
--- a/src/PrizmMainProject/Forms/MainChildForm/FirstSetupForm/FirstSetupSaveCommand.cs
+++ b/src/PrizmMainProject/Forms/MainChildForm/FirstSetupForm/FirstSetupSaveCommand.cs
@@ -44,7 +44,6 @@ namespace Prizm.Main.Forms.MainChildForm.FirstSetupForm
                 viewModel.Project.IsActive = true;
                 if (viewModel.Project.WorkstationType != Domain.Entity.Setup.WorkstationType.Mill)
                 {
-                    viewModel.MillName = string.Empty;
                     viewModel.MillPipeNumberMask = string.Empty;
                 }
 


### PR DESCRIPTION
PRISM-79 First setup screen at Master and Construction allows to enter Mill data
