### PR TITLE
Set positive mask for inspection frequency #PRISM-213 Fixed

### DIFF
--- a/src/PrizmMainProject/Forms/Settings/Inspections/MillInspectionXtraForm.cs
+++ b/src/PrizmMainProject/Forms/Settings/Inspections/MillInspectionXtraForm.cs
@@ -94,6 +94,7 @@ namespace Prizm.Main.Forms.Settings.Inspections
             code.SetRequiredText();
             operationName.SetRequiredText();
             controlType.SetRequiredCombo();
+            frequency.SetMask(Constants.PositiveDigitMask);
             frequencyMeasure.SetRequiredCombo();
             resultType.SetRequiredCombo();
             percentOfSelect.SetRequiredText();


### PR DESCRIPTION
Issue:
# PRISM-213 Recurring inspection operation: frequency can be negative
