### PR TITLE
Added backslash for specific characters #PRISM-217 Fixed

### DIFF
--- a/src/Domain/Entity/Setup/Project.cs
+++ b/src/Domain/Entity/Setup/Project.cs
@@ -17,22 +17,31 @@ namespace Prizm.Domain.Entity
 
         public static string FormRegExp(string millPipeNumberMask)
         {
+            List<char> specialCharacters = new List<char> { '.', '(', ')', '*', '+', '|', '{', '}', '^', '[', ']', '-', '\\', ',' };
             StringBuilder mask = new StringBuilder();
             if (millPipeNumberMask != string.Empty && millPipeNumberMask != null)
-            {          
-             foreach (char ch in millPipeNumberMask)
+            {
+                foreach (char ch in millPipeNumberMask)
+                {
+                    string convertedToRegex = "";
+                    if (specialCharacters.Contains(ch))
                     {
-                        string convertedToRegex = "";
+                        convertedToRegex = @"\" + ch;
+                    }
+                    else
+                    {
                         switch (ch)
                         {
-                           case '#': convertedToRegex = @"\d"; break;
-                           case '@': convertedToRegex = @"\p{Lu}"; break;
-                           case '%': convertedToRegex = @"(\d|\p{Lu})"; break;
-                           case '?': convertedToRegex = @"\w"; break;
-                           default: convertedToRegex = ch.ToString(); break;
+                            case '#': convertedToRegex = @"\d"; break;
+                            case '@': convertedToRegex = @"\p{Lu}"; break;
+                            case '%': convertedToRegex = @"(\d|\p{Lu})"; break;
+                            case '?': convertedToRegex = @"\w"; break;
+
+                            default: convertedToRegex = ch.ToString(); break;
                         }
-                        mask.Append(convertedToRegex);
                     }
+                    mask.Append(convertedToRegex);
+                }
             }
             return mask.ToString();
         }


### PR DESCRIPTION
Added backslash for specific characters (meta-character, quantifier, or special character)
Issue:
# PRISM-217 Special mask characters like . ( ) etc, can't be accepted for mask, but they should
