### PR TITLE
Load full-weight  portion for reexport #PRISM-222 Fixed

### DIFF
--- a/src/PrizmMainProject/Forms/Synch/ExportForm.cs
+++ b/src/PrizmMainProject/Forms/Synch/ExportForm.cs
@@ -173,11 +173,15 @@ namespace Prizm.Main.Forms.Synch
 
       private void btnReexport_Click(object sender, EventArgs e)
       {
-         Portion portion = gridViewHistory.GetFocusedRow() as Portion;
-         if (portion != null)
-         {
-            DoExport(portion);
-         }
+          Portion lightPortion = gridViewHistory.GetFocusedRow() as Portion;
+          if (lightPortion != null)
+          {
+              Portion portion = exporter.GetPortionForReexport(lightPortion.Id);
+              if (portion != null)
+              {
+                  DoExport(portion);
+              }
+          }
       }
 
       private void ExportForm_FormClosing(object sender, FormClosingEventArgs e)

--- a/src/PrizmMainProject/Synch/Export/DataExporter.cs
+++ b/src/PrizmMainProject/Synch/Export/DataExporter.cs
@@ -37,6 +37,11 @@ namespace Prizm.Main.Synch.Export
          return exportRepo.PortionRepo.GetAll();
       }
 
+      public Portion GetPortionForReexport(Guid PortionId)
+      {
+          return exportRepo.PortionRepo.Get(PortionId);
+      }
+
       public bool AnyNewDataToExport()
       {
           IList<Pipe> pipesToExport = exportRepo.PipeRepo.GetPipesToExport();


### PR DESCRIPTION
While clicking Reexport button load full-weight  portion (with all elements lists)
Issue:
# PRISM-222 Reexport button doesn't work
