### PR TITLE
Set read-only fields in constructor #PRISM-225 Fixed

### DIFF
--- a/src/PrizmMainProject/Forms/Settings/SettingsViewModel.cs
+++ b/src/PrizmMainProject/Forms/Settings/SettingsViewModel.cs
@@ -71,6 +71,7 @@ namespace Prizm.Main.Forms.Settings
             this.ExtractCategoriesCommand.Execute();
             CategoryTypes.ListChanged += (s, e) => ModifiableView.IsModified = true;
             PipeTests.ListChanged += (s, e) => ModifiableView.IsModified = true;
+            GetProjectSettings();
         }
 
         public void LoadData()
@@ -83,7 +84,7 @@ namespace Prizm.Main.Forms.Settings
            GetAllPermissions();
            GetAllRoles();
            GetAllUsers();
-           GetProjectSettings();
+
            GetAllManufacturers();
            GetAllJointOperations();
            LoadJointOperationTypes();

--- a/src/PrizmMainProject/Forms/Settings/SettingsViewModel.cs
+++ b/src/PrizmMainProject/Forms/Settings/SettingsViewModel.cs
@@ -71,7 +71,7 @@ namespace Prizm.Main.Forms.Settings
             this.ExtractCategoriesCommand.Execute();
             CategoryTypes.ListChanged += (s, e) => ModifiableView.IsModified = true;
             PipeTests.ListChanged += (s, e) => ModifiableView.IsModified = true;
-            GetProjectSettings();
+            
         }
 
         public void LoadData()
@@ -84,7 +84,7 @@ namespace Prizm.Main.Forms.Settings
            GetAllPermissions();
            GetAllRoles();
            GetAllUsers();
-
+           GetProjectSettings();
            GetAllManufacturers();
            GetAllJointOperations();
            LoadJointOperationTypes();
@@ -655,17 +655,17 @@ namespace Prizm.Main.Forms.Settings
 
         public bool IsMaster
         {
-            get { return (CurrentProjectSettings.WorkstationType == WorkstationType.Master) ? true : false; } 
+            get { return (Program.ThisWorkstationType == WorkstationType.Master) ? true : false; } 
         }
 
         public bool IsMill
         {
-            get { return (CurrentProjectSettings.WorkstationType == WorkstationType.Mill) ? true : false; }
+            get { return (Program.ThisWorkstationType == WorkstationType.Mill) ? true : false; }
         }
 
         public bool IsConstruction
         {
-            get { return (CurrentProjectSettings.WorkstationType == WorkstationType.Construction) ? true : false; }
+            get { return (Program.ThisWorkstationType == WorkstationType.Construction) ? true : false; }
         }
     }
 }

--- a/src/PrizmMainProject/Forms/Settings/SettingsXtraForm.cs
+++ b/src/PrizmMainProject/Forms/Settings/SettingsXtraForm.cs
@@ -101,29 +101,33 @@ namespace Prizm.Main.Forms.Settings
             pipeLength.SetRequiredText();
             pipeDiameter.SetRequiredText();
             wallThickness.SetRequiredText();
-            SetConditional(seamType, delegate(bool editMode)
+            
+            if (viewModel.IsMill)
             {
-                return IsEditable(IsEditMode);
-            }
+                SetConditional(pipeDiameter, delegate(bool editMode)
+                {
+                    return IsEditable(IsEditMode);
+                }
+                );
+
+                SetConditional(wallThickness, delegate(bool editMode)
+                {
+                    return IsEditable(IsEditMode);
+                }
+                );
+
+                SetConditional(seamType, delegate(bool editMode)
+                {
+                    return IsEditable(IsEditMode);
+                }
                         );
-            SetConditional(pipeLength, delegate(bool editMode)
-            {
-                return IsEditable(IsEditMode);
-            }
-            );
 
-            SetConditional(pipeDiameter, delegate(bool editMode)
-            {
-                return IsEditable(IsEditMode);
+                SetConditional(pipeLength, delegate(bool editMode)
+                {
+                    return IsEditable(IsEditMode);
+                }
+                );
             }
-            );
-
-            SetConditional(wallThickness, delegate(bool editMode)
-            {
-                return IsEditable(IsEditMode);
-            }
-            );
-
             SetConditional(inspectionOperation, delegate(bool editMode)
             {
                 return IsEditable(IsEditMode);
@@ -2109,7 +2113,11 @@ namespace Prizm.Main.Forms.Settings
                 SetAlwaysReadOnly(gridControlInspectors);
                 SetAlwaysReadOnly(gridControlInspectorsCertificates);
                 SetAlwaysReadOnly(certificateTypes);
-
+                SetAlwaysReadOnly(pipeDiameter);
+                SetAlwaysReadOnly(wallThickness);
+                SetAlwaysReadOnly(pipeLength);
+                SetAlwaysReadOnly(seamType);
+                
             }
             if (viewModel.IsMill)
             {
@@ -2129,6 +2137,10 @@ namespace Prizm.Main.Forms.Settings
                 SetAlwaysReadOnly(categoriesGrid);
                 SetAlwaysReadOnly(seamTypes);
                 SetAlwaysReadOnly(pipesSizeList);
+                SetAlwaysReadOnly(pipeDiameter);
+                SetAlwaysReadOnly(wallThickness);
+                SetAlwaysReadOnly(pipeLength);
+                SetAlwaysReadOnly(seamType);
             }
         }
         

--- a/src/PrizmMainProject/Forms/Settings/SettingsXtraForm.cs
+++ b/src/PrizmMainProject/Forms/Settings/SettingsXtraForm.cs
@@ -72,6 +72,7 @@ namespace Prizm.Main.Forms.Settings
             plateManufacturersListView.OptionsView.NewItemRowPosition = NewItemRowPosition.Bottom;
             jointsOperationsGridView.OptionsView.NewItemRowPosition = NewItemRowPosition.Bottom;
             viewModel.ModifiableView = this;
+            SetWorkstationReadonlyFields();
         }
 
 
@@ -134,7 +135,7 @@ namespace Prizm.Main.Forms.Settings
             //    return IsEditableCrtificate(IsEditMode);
             //}
             //);
-            SetWorkstationReadonlyFields();
+
             UpdateSeamTypesComboBox();
             ISecurityContext ctx = Program.Kernel.Get<ISecurityContext>();
             IsEditMode &= ctx.HasAccess(global::Domain.Entity.Security.Privileges.EditSettings);


### PR DESCRIPTION
Settings form: set read-only fields in constructor
Make mill size type parameters read-only for master and construction workstation types
Issue:
# PRISM-225 Settings form: Fields become read-only only after reactivating tab
