### PR TITLE
 System.InvalidOperationException #PRISM-233 Fixed

### DIFF
--- a/src/PrizmMainProject/Forms/MainChildForm/PrizmApplicationXtraForm.cs
+++ b/src/PrizmMainProject/Forms/MainChildForm/PrizmApplicationXtraForm.cs
@@ -379,10 +379,20 @@ namespace Prizm.Main.Forms.MainChildForm
             {
                 InvokeIfRequired(queueAppWaitForm.Peek(), () =>
                 {
-                    var tempAppWaitForm = queueAppWaitForm.Dequeue();
 
-                    tempAppWaitForm.Close();
-                    tempAppWaitForm.Dispose();
+                    try
+                    {
+                        var tempAppWaitForm = queueAppWaitForm.Dequeue();
+
+                        tempAppWaitForm.Close();
+                        tempAppWaitForm.Dispose();
+                    }
+                    catch(InvalidOperationException e)
+                    {
+
+                        log.Warn(string.Concat(appWaitForm.GetType().Name, e.Message));
+                    }
+                    
                 });
             }
 


### PR DESCRIPTION
 System.InvalidOperationException: Value Close() cannot be called while doing CreateHandle().

wrap close & dispose method
