### PR TITLE
Elements with all used connectors displaying #PRISM-248 Fixed

### DIFF
--- a/src/PrizmMainProject/Forms/Joint/NewEdit/JointNewEditViewModel.cs
+++ b/src/PrizmMainProject/Forms/Joint/NewEdit/JointNewEditViewModel.cs
@@ -916,6 +916,11 @@ namespace Prizm.Main.Forms.Joint.NewEdit
         {
             this.list = null;
             this.Pieces = adoRepo.GetPipelineElements();
+            if (!Joint.IsNew())
+            {
+                this.firstElement = GetPartDataFromList(Joint.FirstElement, GetPart(Joint.FirstElement));
+                this.secondElement = GetPartDataFromList(Joint.SecondElement, GetPart(Joint.SecondElement));
+            }
         }
 
         public void JointCut()


### PR DESCRIPTION
After refreshing list, refresh properties for existing joints
Issue:
# PRISM-248 Joint that has element with all used connectors has empty First joint element or Second joint element field
