### PR TITLE
Disable incoming inspection for welded elements #PRISM-243 Fixed

### DIFF
--- a/src/PrizmMainProject/Forms/Parts/Inspection/SearchPartForInspectionCommand.cs
+++ b/src/PrizmMainProject/Forms/Parts/Inspection/SearchPartForInspectionCommand.cs
@@ -45,7 +45,6 @@ namespace Prizm.Main.Forms.Parts.Inspection
 
             foreach (var item in qparts)
             {
-                if(item.IsActive)
                 parts.Add(item);
             }
 

--- a/src/PrizmMainProject/Forms/Parts/Search/PartQuery.cs
+++ b/src/PrizmMainProject/Forms/Parts/Search/PartQuery.cs
@@ -115,11 +115,16 @@ namespace Prizm.Main.Forms.Parts.Search
                 number = string.Format(@"WHERE number LIKE N'{0}%' ESCAPE '\' ", number.EscapeCharacters());
             }
             return string.Format(
-                                @"SELECT id, number, isActive,'{1}' FROM Pipe {0}
-                                UNION ALL
-                                SELECT id, number, isActive,'{2}' FROM Spool {0}
-                                UNION ALL
-                                SELECT id, number, isActive,'{3}' FROM Component {0}  ORDER BY number ASC ", number, PartType.Pipe, PartType.Spool, PartType.Component
+                                @"SELECT elem.id, elem.number, elem.isActive, elem.parttype FROM 
+                                    (SELECT id, number, isActive,'{1}' as parttype FROM Pipe {0}
+                                    UNION ALL
+                                    SELECT id, number, isActive,'{2}'  as parttype FROM Spool {0}
+                                    UNION ALL
+                                    SELECT id, number, isActive,'{3}'  as parttype FROM Component {0}) elem
+                                LEFT JOIN Joint  p1 ON elem.id = p1.part1Id
+                                LEFT JOIN Joint  p2 ON elem.id = p2.part2Id
+                                WHERE p1.id IS NULL AND p2.id IS NULL AND elem.isActive = 1
+                                ORDER BY number ASC ", number, PartType.Pipe, PartType.Spool, PartType.Component
                                 );
 
 

--- a/src/PrizmMainProject/Forms/Spool/SpoolsXtraForm.cs
+++ b/src/PrizmMainProject/Forms/Spool/SpoolsXtraForm.cs
@@ -69,7 +69,7 @@ namespace Prizm.Main.Forms.Spool
                 {
                     SetConditional(inspectionHistory, delegate(bool editMode)
                     {
-                        return !(viewModel.Spool.ConstructionStatus == PartConstructionStatus.Welded); 
+                        return (viewModel.Spool.ConstructionStatus != PartConstructionStatus.Welded); 
                     });
                 }
 

--- a/src/PrizmMainProject/Forms/Spool/SpoolsXtraForm.cs
+++ b/src/PrizmMainProject/Forms/Spool/SpoolsXtraForm.cs
@@ -50,6 +50,7 @@ namespace Prizm.Main.Forms.Spool
                 viewModel.SpoolNumber = number;
             }
             SetAlwaysReadOnly(pipeLength);
+
             if(id == Guid.Empty)
             {
                 SetAlwaysEditable(pipeNumber);
@@ -58,12 +59,20 @@ namespace Prizm.Main.Forms.Spool
             {
                 this.Text = Program.LanguageManager.GetString(StringResources.Spool_EditDocumentHeader);
                 SetAlwaysReadOnly(pipeNumber);
-                if(Program.ThisWorkstationType == Domain.Entity.Setup.WorkstationType.Master)
+                if (Program.ThisWorkstationType == Domain.Entity.Setup.WorkstationType.Master)
                 {
                     SetAlwaysReadOnly(spoolNumber);
                     SetAlwaysReadOnly(spoolLength);
                     SetAlwaysReadOnly(inspectionHistory);
                 }
+                else 
+                {
+                    SetConditional(inspectionHistory, delegate(bool editMode)
+                    {
+                        return !(viewModel.Spool.ConstructionStatus == PartConstructionStatus.Welded); 
+                    });
+                }
+
             }
             IsEditMode = true;//do not remove until IsEditMode logic is changed
             IsEditMode = ctx.HasAccess(global::Domain.Entity.Security.Privileges.EditSpool);
@@ -74,6 +83,7 @@ namespace Prizm.Main.Forms.Spool
             spoolLength.SetMask(Constants.PositiveDigitMask);
             spoolLength.Properties.MinValue = Constants.MinSpoolCut;
             spoolLength.Properties.MaxValue = viewModel.InitPipeLenght - Constants.MinSpoolCut;
+
         }
 
         public SpoolsXtraForm() : this(Guid.Empty, string.Empty) { }


### PR DESCRIPTION
Incoming inspection: elements that have any welded connectors are not displayed in search results
Spool: incoming inspection grid is disabled if any side of spool is welded
Issue:
# PRISM-243 Incoming inspection of elements that are already welded in joint should not be performed
