### PR TITLE
Do not display elements used in deactivated joint #PRISM-247 Fixed

### DIFF
--- a/src/Data/DAL/ADO/SQLQueryString.cs
+++ b/src/Data/DAL/ADO/SQLQueryString.cs
@@ -164,32 +164,32 @@ Pipe.length as length, Heat.number as Heat_number, InspectionTestResult.status a
         private const string GetAllUsedPipe = @"select Pipe.number as number, Joint.part1Type as " + ColumnNameForUsedProductsReport + @", Joint.numberKP
           from  Joint Joint
 		  inner join Pipe on (Pipe.id = Joint.[part1Id]) 
-		  where Joint.numberKP >= @startPK and Joint.numberKP <= @endPK AND Pipe.isActive=1
+		  where Joint.numberKP >= @startPK and Joint.numberKP <= @endPK AND Pipe.isActive=1 AND Joint.isActive = 1
 		  union
 select Pipe.number as number, Joint.part2Type as type, Joint.numberKP
           from  Joint Joint
 		  inner join Pipe on (Pipe.id = Joint.[part2Id]) 
-		  where Joint.numberKP >= @startPK and Joint.numberKP <= @endPK AND Pipe.isActive=1";
+		  where Joint.numberKP >= @startPK and Joint.numberKP <= @endPK AND Pipe.isActive=1 AND Joint.isActive = 1";
 
         private const string GetAllUsedSpool = @"select Spool.number as number, Joint.part1Type as type, Joint.numberKP
           from  Joint Joint
 		  inner join Spool on (Spool.id = Joint.[part1Id]) 
-		  where Joint.numberKP >= @startPK and Joint.numberKP <= @endPK AND Spool.isActive=1
+		  where Joint.numberKP >= @startPK and Joint.numberKP <= @endPK AND Spool.isActive=1 AND Joint.isActive = 1
 		  union 
 select Spool.number as number, Joint.part2Type as type, Joint.numberKP
           from  Joint Joint
 		  inner join Spool on (Spool.id = Joint.[part2Id]) 
-		  where Joint.numberKP >= @startPK and Joint.numberKP <= @endPK AND Spool.isActive=1";
+		  where Joint.numberKP >= @startPK and Joint.numberKP <= @endPK AND Spool.isActive=1 AND Joint.isActive = 1";
 
         private const string GetAllUsedComponent = @"select Component.number as number, Joint.part1Type as type, Joint.numberKP
           from  Joint Joint
 		  inner join Component on (Component.id = Joint.[part1Id]) 
-		  where Joint.numberKP >= @startPK and Joint.numberKP <= @endPK AND Component.isActive=1
+		  where Joint.numberKP >= @startPK and Joint.numberKP <= @endPK AND Component.isActive=1 AND Joint.isActive = 1
 		  union
 select Component.number as number, Joint.part2Type as type, Joint.numberKP
           from  Joint Joint
 		  inner join Component on (Component.id = Joint.[part2Id])
-		  where Joint.numberKP >=@startPK and Joint.numberKP <= @endPK  AND Component.isActive=1";
+		  where Joint.numberKP >=@startPK and Joint.numberKP <= @endPK  AND Component.isActive=1 AND Joint.isActive = 1";
 
         private const string GetWeldedParts =
           @"SELECT 


### PR DESCRIPTION
Do not display elements used in deactivated joint in Used products report
Issue:
# PRISM-247 Elements used in deactivated joint are displayed in used products report
