### PR TITLE
System allowed to save inspection with % pipes 0 #PRISM-231 Fixed

### DIFF
--- a/src/PrizmMainProject/Common/Constants.cs
+++ b/src/PrizmMainProject/Common/Constants.cs
@@ -36,5 +36,10 @@ namespace Prizm.Main.Common
         /// Number of digits before the decimal point
         /// </summary>
         public const int DigitsBeforeDecimalPoint = 6;
+
+       /// <summary>
+       /// Mininum value for percent of selective inspection operation
+       /// </summary>
+        public const int MinSelectivePercent = 1;
     }
 }

--- a/src/PrizmMainProject/Forms/Settings/Inspections/MillInspectionXtraForm.cs
+++ b/src/PrizmMainProject/Forms/Settings/Inspections/MillInspectionXtraForm.cs
@@ -32,6 +32,7 @@ namespace Prizm.Main.Forms.Settings.Inspections
         {
             InitializeComponent();
             this.SetupForm(current, categoryTypes, pipeTestList, usedCodes);
+            percentOfSelect.Properties.MinValue = Constants.MinSelectivePercent;
         }
 
         private MillInspectionViewModel GetInspectionViewModel(PipeTest current, BindingList<Category> categoryTypes)


### PR DESCRIPTION
Set in constructor min value for field
Issue:
# PRISM-231 System allowed to save inspection with % pipes 0
