### PR TITLE
Pipe measure and joint weld operation should not be deactivated #PRISM-259 Fixed

### DIFF
--- a/src/PrizmMainProject/Forms/Settings/Inspections/MillInspectionXtraForm.cs
+++ b/src/PrizmMainProject/Forms/Settings/Inspections/MillInspectionXtraForm.cs
@@ -359,10 +359,14 @@ namespace Prizm.Main.Forms.Settings.Inspections
             {
                 viewModel.ResultType = PipeTestResultType.Diapason;
                 resultType.ReadOnly = true;
+                isActive.ReadOnly = true;
+                frequencyType.ReadOnly = true;
             }
             else
             {
                 resultType.ReadOnly = false;
+                isActive.ReadOnly = false;
+                frequencyType.ReadOnly = false;
             }
         }
 

--- a/src/PrizmMainProject/Forms/Settings/SettingsXtraForm.Designer.cs
+++ b/src/PrizmMainProject/Forms/Settings/SettingsXtraForm.Designer.cs
@@ -1215,6 +1215,7 @@ namespace Prizm.Main.Forms.Settings
             this.jointsOperationsGridView.InitNewRow += new DevExpress.XtraGrid.Views.Grid.InitNewRowEventHandler(this.jointsOperationsGridView_InitNewRow);
             this.jointsOperationsGridView.CellValueChanged += new DevExpress.XtraGrid.Views.Base.CellValueChangedEventHandler(this.CellModifiedGridView_CellValueChanged);
             this.jointsOperationsGridView.ValidateRow += new DevExpress.XtraGrid.Views.Base.ValidateRowEventHandler(this.jointsOperationsGridView_ValidateRow);
+            this.jointsOperationsGridView.ShowingEditor += new System.ComponentModel.CancelEventHandler(this.jointsOperationsGridView_ShowingEditor);
             // 
             // nameGridColumn
             // 

--- a/src/PrizmMainProject/Forms/Settings/SettingsXtraForm.cs
+++ b/src/PrizmMainProject/Forms/Settings/SettingsXtraForm.cs
@@ -996,6 +996,7 @@ namespace Prizm.Main.Forms.Settings
             GridView v = sender as GridView;
             JointOperation jointOperation = v.GetRow(e.RowHandle) as JointOperation;
             jointOperation.IsActive = true;
+            jointOperation.IsRequired = true;
         }
 
         private void repositoryItemsСategoryView_CustomRowFilter(object sender, RowFilterEventArgs e)
@@ -2152,5 +2153,19 @@ namespace Prizm.Main.Forms.Settings
         {
             BindingHelper.CorrectDecimalSeparator(sender, e);
         }
+
+        private void jointsOperationsGridView_ShowingEditor(object sender, CancelEventArgs e)
+        {
+            GridView view = sender as GridView;
+            JointOperation selectedOperation = view.GetRow(view.FocusedRowHandle) as JointOperation;
+            if (selectedOperation != null
+                && selectedOperation.Type == JointOperationType.Weld
+                && (view.FocusedColumn.Name == isRequiredForJointGridColumn.Name 
+                || view.FocusedColumn.Name == isActiveJointOperationGridColumn.Name))
+            {
+                e.Cancel = true;
+            }
+        }
+
     }
 }


### PR DESCRIPTION
Made Is active and is required fields read-only if inspection is pipe length measure or joint welding
Issue:
# PRISM-259 Pipe measure length and joint welding operation should not be deactivated and be always required
