### PR TITLE
Match mode for LIKE should be only at start #PRISM-118

### DIFF
--- a/src/Data/DAL/ADO/MillReportsRepository.cs
+++ b/src/Data/DAL/ADO/MillReportsRepository.cs
@@ -453,7 +453,7 @@ namespace Prizm.Data.DAL.ADO
 
             tempSQLObject = SQLProvider.GetQuery(
                 SQLProvider.SQLStatic.GetPipeByParametersPieces)
-                .WhereAnd().Where("p.number", "LIKE", string.Concat(" N'%", pipeNumber, "%'"))
+                .WhereAnd().Where("p.number", "LIKE", string.Concat(" N'", pipeNumber, "%'"))
                 .WhereAnd().Where("PmSt.type", "IN", types);
 
             return GetPipelineElements(tempSQLObject.ToString());

--- a/src/Data/DAL/Hibernate/ReleaseNoteRepository.cs
+++ b/src/Data/DAL/Hibernate/ReleaseNoteRepository.cs
@@ -78,7 +78,7 @@ namespace Prizm.Data.DAL.Hibernate
 
                 if(!string.IsNullOrWhiteSpace(number))
                 {
-                    s.WhereRestrictionOn(x => x.Number).IsInsensitiveLike(number, MatchMode.Anywhere);
+                    s.WhereRestrictionOn(x => x.Number).IsInsensitiveLike(number, MatchMode.Start);
                 }
 
                 if(startDate != DateTime.MinValue && endDate != DateTime.MinValue)
@@ -109,22 +109,22 @@ namespace Prizm.Data.DAL.Hibernate
 
                 if(!string.IsNullOrWhiteSpace(railcar))
                 {
-                    s.WhereRestrictionOn(() => car.Number).IsInsensitiveLike(railcar, MatchMode.Anywhere);
+                    s.WhereRestrictionOn(() => car.Number).IsInsensitiveLike(railcar, MatchMode.Start);
                 }
 
                 if(!string.IsNullOrWhiteSpace(number))
                 {
-                    s.WhereRestrictionOn(x => x.Number).IsInsensitiveLike(number, MatchMode.Anywhere);
+                    s.WhereRestrictionOn(x => x.Number).IsInsensitiveLike(number, MatchMode.Start);
                 }
 
                 if(!string.IsNullOrWhiteSpace(certificate))
                 {
-                    s.WhereRestrictionOn(() => car.Certificate).IsInsensitiveLike(certificate, MatchMode.Anywhere);
+                    s.WhereRestrictionOn(() => car.Certificate).IsInsensitiveLike(certificate, MatchMode.Start);
                 }
 
                 if(!string.IsNullOrWhiteSpace(reciver))
                 {
-                    s.WhereRestrictionOn(() => car.Destination).IsInsensitiveLike(reciver, MatchMode.Anywhere);
+                    s.WhereRestrictionOn(() => car.Destination).IsInsensitiveLike(reciver, MatchMode.Start);
                 }
 
                 if(startDate != DateTime.MinValue && endDate != DateTime.MinValue)
@@ -162,24 +162,24 @@ namespace Prizm.Data.DAL.Hibernate
 
                 if(!string.IsNullOrWhiteSpace(pipeNumber))
                 {
-                    s.WhereRestrictionOn(() => pipe.Number).IsInsensitiveLike(pipeNumber, MatchMode.Anywhere);
+                    s.WhereRestrictionOn(() => pipe.Number).IsInsensitiveLike(pipeNumber, MatchMode.Start);
                 }
 
                 if(!string.IsNullOrWhiteSpace(railcar))
                 {
-                    s.WhereRestrictionOn(() => car.Number).IsInsensitiveLike(railcar, MatchMode.Anywhere);
+                    s.WhereRestrictionOn(() => car.Number).IsInsensitiveLike(railcar, MatchMode.Start);
                 }
                 if(!string.IsNullOrWhiteSpace(number))
                 {
-                    s.WhereRestrictionOn(x => x.Number).IsInsensitiveLike(number, MatchMode.Anywhere);
+                    s.WhereRestrictionOn(x => x.Number).IsInsensitiveLike(number, MatchMode.Start);
                 }
                 if(!string.IsNullOrWhiteSpace(certificate))
                 {
-                    s.WhereRestrictionOn(() => car.Certificate).IsInsensitiveLike(certificate, MatchMode.Anywhere);
+                    s.WhereRestrictionOn(() => car.Certificate).IsInsensitiveLike(certificate, MatchMode.Start);
                 }
                 if(!string.IsNullOrWhiteSpace(reciver))
                 {
-                    s.WhereRestrictionOn(() => car.Destination).IsInsensitiveLike(reciver, MatchMode.Anywhere);
+                    s.WhereRestrictionOn(() => car.Destination).IsInsensitiveLike(reciver, MatchMode.Start);
                 }
                 if(startDate != DateTime.MinValue && endDate != DateTime.MinValue)
                 {

--- a/src/Data/DAL/Hibernate/SimpleNoteRepository.cs
+++ b/src/Data/DAL/Hibernate/SimpleNoteRepository.cs
@@ -55,7 +55,7 @@ namespace Prizm.Data.DAL.Hibernate
 
                 if(!string.IsNullOrWhiteSpace(number))
                 {
-                    s.WhereRestrictionOn(x => x.Number).IsInsensitiveLike(number, MatchMode.Anywhere);
+                    s.WhereRestrictionOn(x => x.Number).IsInsensitiveLike(number, MatchMode.Start);
                 }
 
                 if(startDate != DateTime.MinValue && endDate != DateTime.MinValue)
@@ -86,22 +86,22 @@ namespace Prizm.Data.DAL.Hibernate
 
                 if(!string.IsNullOrWhiteSpace(railcar))
                 {
-                    s.WhereRestrictionOn(() => car.Number).IsInsensitiveLike(railcar, MatchMode.Anywhere);
+                    s.WhereRestrictionOn(() => car.Number).IsInsensitiveLike(railcar, MatchMode.Start);
                 }
 
                 if(!string.IsNullOrWhiteSpace(number))
                 {
-                    s.WhereRestrictionOn(x => x.Number).IsInsensitiveLike(number, MatchMode.Anywhere);
+                    s.WhereRestrictionOn(x => x.Number).IsInsensitiveLike(number, MatchMode.Start);
                 }
 
                 if(!string.IsNullOrWhiteSpace(certificate))
                 {
-                    s.WhereRestrictionOn(() => car.Certificate).IsInsensitiveLike(certificate, MatchMode.Anywhere);
+                    s.WhereRestrictionOn(() => car.Certificate).IsInsensitiveLike(certificate, MatchMode.Start);
                 }
 
                 if(!string.IsNullOrWhiteSpace(reciver))
                 {
-                    s.WhereRestrictionOn(() => car.Destination).IsInsensitiveLike(reciver, MatchMode.Anywhere);
+                    s.WhereRestrictionOn(() => car.Destination).IsInsensitiveLike(reciver, MatchMode.Start);
                 }
 
                 if(startDate != DateTime.MinValue && endDate != DateTime.MinValue)
@@ -133,24 +133,24 @@ namespace Prizm.Data.DAL.Hibernate
 
                 if(!string.IsNullOrWhiteSpace(pipeNumber))
                 {
-                    s.WhereRestrictionOn(() => pipe.Number).IsInsensitiveLike(pipeNumber, MatchMode.Anywhere);
+                    s.WhereRestrictionOn(() => pipe.Number).IsInsensitiveLike(pipeNumber, MatchMode.Start);
                 }
 
                 if(!string.IsNullOrWhiteSpace(railcar))
                 {
-                    s.WhereRestrictionOn(() => car.Number).IsInsensitiveLike(railcar, MatchMode.Anywhere);
+                    s.WhereRestrictionOn(() => car.Number).IsInsensitiveLike(railcar, MatchMode.Start);
                 }
                 if(!string.IsNullOrWhiteSpace(number))
                 {
-                    s.WhereRestrictionOn(x => x.Number).IsInsensitiveLike(number, MatchMode.Anywhere);
+                    s.WhereRestrictionOn(x => x.Number).IsInsensitiveLike(number, MatchMode.Start);
                 }
                 if(!string.IsNullOrWhiteSpace(certificate))
                 {
-                    s.WhereRestrictionOn(() => car.Certificate).IsInsensitiveLike(certificate, MatchMode.Anywhere);
+                    s.WhereRestrictionOn(() => car.Certificate).IsInsensitiveLike(certificate, MatchMode.Start);
                 }
                 if(!string.IsNullOrWhiteSpace(reciver))
                 {
-                    s.WhereRestrictionOn(() => car.Destination).IsInsensitiveLike(reciver, MatchMode.Anywhere);
+                    s.WhereRestrictionOn(() => car.Destination).IsInsensitiveLike(reciver, MatchMode.Start);
                 }
                 if(startDate != DateTime.MinValue && endDate != DateTime.MinValue)
                 {

--- a/src/PrizmMainProject/Forms/Parts/Search/PartQuery.cs
+++ b/src/PrizmMainProject/Forms/Parts/Search/PartQuery.cs
@@ -50,15 +50,15 @@ namespace Prizm.Main.Forms.Parts.Search
             {
                 if (Activity == ActivityCriteria.StatusActive)
                 {
-                    number = string.Format(@"WHERE isActive = N'{0}' and number LIKE N'%{1}%' ESCAPE '\' ", true ,number.EscapeCharacters()); 
+                    number = string.Format(@"WHERE isActive = N'{0}' and number LIKE N'{1}%' ESCAPE '\' ", true ,number.EscapeCharacters()); 
                 }
                 else if (Activity == ActivityCriteria.StatusUnactive)
                 {
-                    number = string.Format(@"WHERE isActive = N'{0}' and number LIKE N'%{1}%' ESCAPE '\' ", false, number.EscapeCharacters());
+                    number = string.Format(@"WHERE isActive = N'{0}' and number LIKE N'{1}%' ESCAPE '\' ", false, number.EscapeCharacters());
                 }
                 else
                 {
-                    number = string.Format(@"WHERE number LIKE N'%{0}%' ESCAPE '\' ", number.EscapeCharacters());
+                    number = string.Format(@"WHERE number LIKE N'{0}%' ESCAPE '\' ", number.EscapeCharacters());
                 }
             }
 

--- a/src/PrizmMainProject/Forms/PipeMill/Search/PipeQuery.cs
+++ b/src/PrizmMainProject/Forms/PipeMill/Search/PipeQuery.cs
@@ -71,7 +71,7 @@ namespace Prizm.Main.Forms.PipeMill.Search
                          left join [PurchaseOrder] on ([PurchaseOrder].[id] = [Pipe].[purchaseOrderId])
                          left join [PipeMillSizeType] on ([PipeMillSizeType].[id] = [Pipe].[typeId]) ");
 
-            sb.Append(string.Format(@" WHERE [Pipe].[number] LIKE N'%{0}%' ESCAPE '\' ", Number.EscapeCharacters()));
+            sb.Append(string.Format(@" WHERE [Pipe].[number] LIKE N'{0}%' ESCAPE '\' ", Number.EscapeCharacters()));
 
             if (CheckedPipeTypes.Count > 0)
             {


### PR DESCRIPTION
Make sure that data are searched by start of ID, not by occurence in any place.
Issue:
PRISM-118 LIKE and IsActive
